### PR TITLE
remove federalist-docs references

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Fixes issue(s) #[ISSUE ID] .
 
-[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist-docs/tree/[BRANCH_NAME])
+[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/[BRANCH_NAME])
 
 [:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/[BRANCH_NAME]/)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Federalist documentation
 
-This is an informational site with background on [Federalist](https://federalist-docs.18f.gov/), a compliant static site publishing service for the federal government.
+This is an informational site with background on [Federalist](https://federalist.18f.gov/), a compliant static site publishing service for the federal government.
 
 ## Setup
 

--- a/pages/features.md
+++ b/pages/features.md
@@ -52,7 +52,7 @@ layout: home
               </div>
               <div class="feature-text">
                 <h5>Accessible templates</h5>
-                <p><a href="https://federalist-docs.18f.gov/pages/using-federalist/templates/">Our 508-compliant website templates</a> help you kickstart your design process.</p>
+                <p><a href="https://federalist.18f.gov/pages/using-federalist/templates/">Our 508-compliant website templates</a> help you kickstart your design process.</p>
               </div>
             </div>
           </div>

--- a/pages/how-federalist-works/how-builds-work.md
+++ b/pages/how-federalist-works/how-builds-work.md
@@ -62,7 +62,7 @@ To instruct search engines not to index the `preview` builds of your site, try a
 {% endraw %}
 ***Note:*** This code sample assumes the live version of your site's code is maintained in the `master` branch of your site's code repository.
 
-For all versions of your site that aren't built from `master`, the source code of the site will contain the code above. For an example, see [here](https://federalist-proxy.app.cloud.gov/preview/18f/federalist-docs/wslack-patch-1/), view source, and jump to line 57.
+For all versions of your site that aren't built from `master`, the source code of the site will contain the code above. For an example, see [here](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/wslack-patch-1/), view source, and jump to line 57.
 
 ### Jekyll Plugins
 

--- a/pages/how-federalist-works/index.md
+++ b/pages/how-federalist-works/index.md
@@ -17,7 +17,7 @@ We use GitHub to manage our work on Federalist. The main code repository for the
 - **[federalist-garden-build](https://github.com/18F/federalist-garden-build)** This container image contains the code to build Federalist sites in Garden Linux containers.
 
 ### Documentation
-- **[federalist-docs](https://github.com/18f/federalist-docs/)** This documentation website.
+- **[federalist.18f.gov](https://github.com/18f/federalist.18f.gov/)** The documentation website.
 
 ### Templates
 

--- a/pages/index.md
+++ b/pages/index.md
@@ -193,7 +193,7 @@ layout: home
         <h3>Federalist fact sheets</h3>
         <div class="usa-width-one-third full-width">
           <p class="copy">
-            Need more details about Federalist? Need help convincing your executive team? The Federalist team has developed these resources to help. See more on the <a href="https://federalist-docs.18f.gov/">Federalist support site</a>.
+            Need more details about Federalist? Need help convincing your executive team? The Federalist team has developed these resources to help. See more on the <a href="https://federalist.18f.gov/">Federalist support site</a>.
           </p>
         </div>
         <div class="usa-width-two-thirds figure-group">

--- a/pages/using-federalist/getting-started.md
+++ b/pages/using-federalist/getting-started.md
@@ -18,7 +18,7 @@ You can view the live site [from Federalist][federalist-sites] and clicking
 {% capture content %}
 If you’re unfamiliar with GitHub, the Federalist team recommends that you
 [familiarize
-yourself](https://federalist-docs.18f.gov/pages/using-federalist/instructional-demos/#introduction-to-github-for-newcomers)
+yourself](https://federalist.18f.gov/pages/using-federalist/instructional-demos/#introduction-to-github-for-newcomers)
 before continuing through this guide.
 {% endcapture %}
 {% include components/alert--note.html content=content %}
@@ -160,9 +160,9 @@ commit your changes when you’re done.
 ## Template-specific customization
 
 Some templates are geared toward a specific task, like the [Basic Report
-template](https://federalist-docs.18f.gov/pages/using-federalist/templates/basic-report/),
+template](https://federalist.18f.gov/pages/using-federalist/templates/basic-report/),
 which features a downloadable PDF report. You’ll want to refer to the [template
-specific documentation](https://federalist-docs.18f.gov/pages/using-federalist/templates/)
+specific documentation](https://federalist.18f.gov/pages/using-federalist/templates/)
 to learn how to configure your template beyond what is covered in this guide.
 
 Once you've got the basics down, we recommend that you check out our [customization


### PR DESCRIPTION
Fixes issue(s) #[ISSUE ID] .

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist-docs/tree/[BRANCH_NAME])

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/[BRANCH_NAME]/)

Proposed changes in this pull request:
-
-
-


/cc @relevant-people