### PR TITLE
Corrects official agency name, typo in case studies

### DIFF
--- a/_data/case_studies.yml
+++ b/_data/case_studies.yml
@@ -4,8 +4,8 @@
   thumbnail: /assets/images/partner-sites/vote.gov.png
 
 
-- title: Department of Interior
-  summary: The Department of Interior's Natural Resources Revenue site provides data on the government's managing of energy, mineral resources, revenue, and disbursements. The website emphasizes on delivering timely data to experts that shape policy while also ensuring the generable public can follow along with an intuitive user interface and contextual information. This is an excellent example of how Federalist can be used to manage complex data sets and visualizations. You can learn more about <a href="https://revenuedata.doi.gov/blog/">their process on their blog</a>.
+- title: Department of the Interior
+  summary: The Department of the Interior's Natural Resources Revenue site provides data about how the government manages federal energy and mineral resources, revenue, and disbursements. The website delivers valuable data to policy experts, while also ensuring the general public can follow along through an intuitive user interface and contextual information. This is an excellent example of how Federalist can be used to manage complex data sets and visualizations. You can learn more about <a href="https://revenuedata.doi.gov/blog/">their process on their blog</a>.
   url: https://revenuedata.doi.gov
   thumbnail: /assets/images/partner-sites/revenuedata.doi.gov.png
 


### PR DESCRIPTION


Proposed changes in this pull request:
- corrects DOI reference (Department of _the_ Interior)
- fixes typo ("general")
- other minor edits



[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/BRANCH_NAME/)

