### PR TITLE
Fixed link for cio.gov

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -103,7 +103,7 @@ layout: default
               </a>
             </li>
             <li>
-              <a href="https://fedramp.gov">
+              <a href="https://cio.gov">
               <figure class="figure figure-seal">
                 <div class="tint">
                   <img src="{{site.baseurl}}/assets/images/partner-sites/cio.gov.png" alt="A screenshot of the CIO.gov website">


### PR DESCRIPTION
Fixed the link for cio.gov. It was linking to fedramp.gov.

Fixes issue(s) #[ISSUE ID] .

Proposed changes in this pull request:
-
-
-


/cc @relevant-people


[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/BRANCH_NAME/)

