### PR TITLE
Changed heading & subheading taglines

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -8,7 +8,7 @@ layout: default
   <div class="well">
     <div class="usa-grid federalist-hero">
       <div class="usa-width-two-thirds hero-heading">
-        <h1>Federalist helps federal agencies and offices quickly launch compliant websites.</h1>
+        <h1>There’s no new easier way to launch, maintain, and manage government sites.</h1>
       </div>
       <div class="usa-width-one-third usa-hero-callout">
         <h2 class="contrast-heading">Trusted and scalable</h2>
@@ -24,7 +24,7 @@ layout: default
   </div>
   <div class="usa-grid info-block">
     <hr class="hr-light">
-    <h2><a id="page-body"></a>Rely on Federalist for the heavy lifting.</h2>
+    <h2><a id="page-body"></a>Federalist is a publishing platform for modern, compliant government websites.</h2>
     <section class="features">
       <div class="feature-group">
         <div class="usa-width-one-sixth">

--- a/spec/basic_spec.rb
+++ b/spec/basic_spec.rb
@@ -4,7 +4,7 @@ describe "home page", type: :feature, js: false do
   end
   
   it "has splash message" do
-    expect(page).to have_text("Federalist helps federal agencies and offices quickly launch compliant websites.")    
+    expect(page).to have_text("There’s no new easier way to launch, maintain, and manage government sites.")    
   end
   
   it "should have the images" do


### PR DESCRIPTION
Changed the original heading on the landing page to: There’s no new easier way to launch, maintain, and manage government sites 
Changed the subheading on the landing page to: Federalist is a publishing platform for modern, compliant government websites

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/amirahaziz-patch-1)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/amirahaziz-patch-1/)

