### PR TITLE
Bh remove 2018 new customer ss

### DIFF
--- a/pages/success-stories.md
+++ b/pages/success-stories.md
@@ -19,14 +19,6 @@ redirect_from:
           Nine agencies use Federalist to host over 100 sites with over 140,000 page views per day. This page shows a sample of our partners.
         </p>
       </div>
-      <div class="usa-width-one-third usa-hero-callout">
-        <p class="medium-copy">
-          Federalist welcomes its newest client, <b>GSA's Office of Government Wide Policy Councils Team</b>
-        </p>
-        <p class="small">
-          February 28, 2018
-        </p>
-      </div>
     </div>
   </div>
         

--- a/pages/success-stories.md
+++ b/pages/success-stories.md
@@ -11,7 +11,7 @@ redirect_from:
 <div id="home">
   <div class="well">
     <div class="usa-grid federalist-hero">
-      <div class="usa-width-two-thirds">
+      <div class="usa-width-one-full">
         <h1 class="hero-heading">
           Trusted and scalable.
         </h1>


### PR DESCRIPTION
Fixes issue(s) #[ISSUE ID] .
Removed Success Story box detailing new customer as of Feb 28 2018. As changed top text to be full width instead of two-thirds. Also, chose to do it off the master since it was a quick fix and didn't want to wait for the broader Success Stories dev work to finish.

Proposed changes in this pull request:
-Removed blue box with new customer on success stories page
-Changed text settings to be full width instead of two-thirds width


/cc @amirbey 


[![CircleCI] bh-remove-2018-new-customer-ss 

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/bh-remove-2018-new-customer-ss/success-stories/)

