### PR TITLE
Remove "Homepage" from every page title

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-title: Federalist Homepage
+title: Federalist
 name: Federalist Homepage
 theme: uswds-jekyll
 


### PR DESCRIPTION
Every page, e.g. [Customer Responsiblities](https://federalist.18f.gov/documentation/customer-responsibilities/) has the title "<title> | Federalist Homepage". This removes the "Homepage" part, since many of these are not the homepage.

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/adborden-patch-1.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/adborden-patch-1)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/adborden-patch-1/)

