### PR TITLE
Restore visibility of search input

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -11,5 +11,5 @@ Proposed changes in this pull request:
 
 [![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME)
 
-[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/federalist.18f.gov/BRANCH_NAME/)
+[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/BRANCH_NAME/)
 

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -12,3 +12,10 @@ switch (window.location.hostname){
     // this will catch different local addresses: localhost, 0.0.0.0, 127.0.0.1, etc
     document.querySelector('.usa-nav-secondary-links li:last-child a').href = 'http://localhost:1337';
 }
+
+// Temporary added to ensure the search input is visible to browser users
+//
+// Can be removed once https://github.com/18F/uswds-jekyll/issues/184 is resolved
+// and the dependency is updated.
+//
+document.getElementById('search_form').classList.remove('usa-sr-only');


### PR DESCRIPTION
Fixes issue(s) #348 .

Proposed changes in this pull request:
- Temporarily adds JS to remove the `usa-sr-only` class from the search form to it is visible. Can be removed once `uswds-jekyll` is updated


/cc @eddietejeda @amirbey 


[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/348-search-input.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/348-search-input)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/348-search-input/)