### PR TITLE
Add a docs page for forms.

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -61,6 +61,8 @@ sidenav:
         href: /documentation/launch-checklist/
       - text: Migration guide
         href: /documentation/migration-guide/
+      - text: Forms
+        href: /documentation/forms/
       - text: Adding Search 
         href: /documentation/search/
       - text: Site templates

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -61,7 +61,7 @@ sidenav:
         href: /documentation/launch-checklist/
       - text: Migration guide
         href: /documentation/migration-guide/
-      - text: Forms
+      - text: Adding forms
         href: /documentation/forms/
       - text: Adding search 
         href: /documentation/search/

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -39,23 +39,22 @@ Federalist pages are static websites. This means there is no backend for you to 
 ## Form requirements
 Here are some requirements that may apply to your agency's digital form. 
 
-### The Paperwork Reduction Act (PRA)
-The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if and how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
+#### The Paperwork Reduction Act (PRA)
+* What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: [a fantastic guide](https://pra.digital.gov/) has been written to help you understand if and how PRA is applicable to your form. 
+* When it applies: To [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/), first see if an exemption or generic clearance for common forms applies.
+* Tips: If you do need to get PRA approval, then start early! In some cases it can take 6 to 9 months to [get a form approved](https://pra.digital.gov/clearance-process/) for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
+* How to get started: Get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 
-1. To figure out if PRA applies to your form, first see if an exemption or generic clearance for common forms applies here: [https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
-2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/) In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
-3. After you've started the PRA process, then build the form.
-4. Don't go it alone; get in touch with your agency's PRA contact. [https://pra.digital.gov/contact/](https://pra.digital.gov/contact/)
 
-#### Accessibility
-The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) applies to all executive agencies' public-facing websites. It mandates a modern user experience in government websites. Importantly, it requires accessibility compliance for users with disabilities. We recommend using the [United States Web Design System](https://designsystem.digital.gov/) for your form. Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
+#### 508 Accessibility
+What it is: [508](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) reinforces this accessibility, and requires a modern user experience.
+Tips: We recommend using the [United States Web Design System](https://designsystem.digital.gov/) for your form. Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
 - [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
 - A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/).
 
-The USWDS has [508](https://www.section508.gov/manage/laws-and-policies) compliance built in. If you end up creating a form without using the USWDS, you'll need to do the work to make your form accessible. Use [https://accessibility.18f.gov/](https://accessibility.18f.gov/) as a guide.
+The USWDS has ben built to include accessibility and modern web design. It is still best practice to [scan for accessibility compliance](https://accessibility.18f.gov/tools/). If you end up creating a form without using the USWDS, you'll need to do the work to make your form accessible. Use [https://accessibility.18f.gov/](https://accessibility.18f.gov/) as a guide.
 
-#### Privacy
-Any forms collecting Personally Identifiable Information (PII) will have to comply with their agency's Privacy process. Here is GSA's for reference: [https://before-you-ship.18f.gov/privacy/](https://before-you-ship.18f.gov/privacy/).
+#### Privacy Act
+What it is: https://www.archives.gov/about/laws/privacy-act-1974.html
 
-#### SORN
-The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agency publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
+Any forms collecting Personally Identifiable Information (PII) will have to comply with their agency's Privacy process. Here is GSA's for reference: [https://before-you-ship.18f.gov/privacy/](https://before-you-ship.18f.gov/privacy/). The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agency publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -10,7 +10,7 @@ This page will help you navigate form rules and choose which technology is appro
 A number of rules may apply to your federal agency's digital form. 
 
 ### The Paperwork Reduction Act (PRA)
-The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if any how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
+The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if and how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
 
 1. To figure out if PRA applies to your form, first see if an exemption or generic clearance for common forms applies here: [https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
 2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/) In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
@@ -28,7 +28,7 @@ The USWDS has [508](https://www.section508.gov/manage/laws-and-policies) complia
 Any forms collecting Personally Identifiable Information (PII) will have to comply with their agency's Privacy process. Here is GSA's for reference: [https://before-you-ship.18f.gov/privacy/](https://before-you-ship.18f.gov/privacy/).
 
 #### SORN
-The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agencies publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
+The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agency publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
 
 ## Choosing a form service
 Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -7,7 +7,7 @@ sidenav: documentation
 Do you want to use a digital form to ask questions of the people visiting your Federalist website? Do you want them to fill out a form with their contact info or feedback? This page provides an overview of existing digital form tools and requirements so you can determine which best apply to your situation and get started.
 
 This pages covers:
-* [form services](#choosing-a-form-service)
+* [Form services](#form-services)
 * [Form requirements](#form-requirements)
 
 ## Form services

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -13,25 +13,25 @@ This pages covers:
 ## Choosing a form service
 Federalist pages are static websites. This means there is no backend for you to log into to get your agency's form data. You'll need to use a separate form service to use a digital form on your agency's site. Choosing a service depends on what the purpose of your agency's form is. Here are some options:
 
-[Google Forms](https://www.google.com/forms/about/)
+#### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
 - Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
 - Quick tips:
-* [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
-* Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
+  * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
+  * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
 - To get started, do this/go here.
 
-[GovDelivery](https://granicus.com/solution/govdelivery/)
+#### [GovDelivery](https://granicus.com/solution/govdelivery/)
 - Use cases: sign ups
 - Access: Available for GSA; fully 508 compliant and FedRAMP certified. For others, check with your agency's X group. 
 - To get started, do this/go here.
 
-[HubSpot](https://www.hubspot.com/)
+#### [HubSpot](https://www.hubspot.com/)
 - Use cases: sign ups
 - Access: Available for GSA. For others, check with your agency's X group.
 - To get started, do this/go here.
 
-[Touchpoints](https://touchpoints.digital.gov)
+#### [Touchpoints](https://touchpoints.digital.gov)
 - Use cases: standardized feedback and contact forms, custom forms
 - Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
 - To get started, do this/go here.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -25,12 +25,12 @@ Federalist pages are static websites. This means there is no backend for you to 
 #### [GovDelivery](https://granicus.com/solution/govdelivery/)
 - Use cases: Newsletter sign ups
 - Access: Available for GSA; fully 508 compliant and FedRAMP certified.
-- To get started: Check this [FedRamp link](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery) to see if your agency has access.
+- To get started: Check this [FedRamp link](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery) to see if your agency has access. Talk to your Chief Information Security Office (CISO) to get an account.
 
 #### [HubSpot](https://www.hubspot.com/)
 - Use cases: sign ups
-- Access: Available for GSA. For others, check with your agency's X group.
-- To get started: Talk to your agency's CISO office to find out if you have access.
+- Access: Available for GSA.
+- To get started: Talk to your agency's CISO office to find out if you have access and can get an account.
 
 #### [Touchpoints](https://feedback.usa.gov/touchpoints/)
 - Use cases: standardized feedback and contact forms, custom forms

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,7 +4,7 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
-Looking to post a digital form to your federal agency's Federalist site? This page provides an overview of existing ditigal form tools and requirements so you can determine which best apply to your agency's situation and get started.
+Do you need to ask questions of the people visiting your Federalist website? Do you need to ask for their contact info or let them give you feedback? You need a form. This page provides an overview of existing digital form tools and requirements so you can determine which best apply to your agency's situation and get started.
 
 This pages covers:
 * [Choosing a form service](#choosing-a-form-service)
@@ -14,17 +14,18 @@ This pages covers:
 Federalist pages are static websites. This means there is no backend for you to log into to get your agency's form data. You'll need to use a separate form service to use a digital form on your agency's site. Choosing a service depends on what the purpose of your agency's form is. Here are some options:
 
 #### [Google Forms](https://www.google.com/forms/about/)
-- Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
+- Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms
 - Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
 - Quick tips:
   * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
   * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
-- To get started, do this/go here.
+  * Some agencies block Google forms, so if you need government employees to answer provide and alternative, such as an email address.
+- To get started: Talk to Federalist staff to find out if your agency allows access to Google services.
 
 #### [GovDelivery](https://granicus.com/solution/govdelivery/)
-- Use cases: sign ups
-- Access: Available for GSA; fully 508 compliant and FedRAMP certified. For others, check with your agency's X group. 
-- To get started, do this/go here.
+- Use cases: Newsletter sign ups
+- Access: Available for GSA; fully 508 compliant and FedRAMP certified.
+- To get started: Check this [FedRamp link](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery) to see if your agency has access.
 
 #### [HubSpot](https://www.hubspot.com/)
 - Use cases: sign ups

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -11,7 +11,7 @@ This pages covers:
 * [Form requirements](#form-requirements)
 
 ## Form services
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers, identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact [Federalist product owners](federalist-support@gsa.gov) if you see other service providers that should be added.
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers, identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact Federalist product owners at federalist-support@gsa.gov if you see other service providers that should be added.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,20 +4,26 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
+This page will help you navigate form rules and choose what technology is appropriate.
 
-When adding a form to your Federalist website, you need to answer two main questions:
-1. Does your form need to go through the Paperwork Reduction Act process?
-2. What technology will best serve your form's purpose?
-
-Forms in the Federal government have a lot of rules around what is allowed. This page will help you navigate those rules and help to choose what technology is appropriate.
+## Form rules
+A number of rules may apply to your federal agency's digital form. 
 
 ### The Paperwork Reduction Act (PRA)
-The PRA can be a complicated and lengthy process. It can take **6 to 9 months** to get a form approved for your website! Luckily, a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help your understanding of the PRA and its applicability to your form.
+The Paperwork Reduction Act (PRA) determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if any how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
 
-1. Figure out if your form needs to go through the PRA process. There are a handful of exemptions. Also, some agencies have generic clearances in place for common forms already. [https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
-2. For help, get in touch with your agency's PRA contact. [https://pra.digital.gov/contact/](https://pra.digital.gov/contact/)
-3. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/)
-4. After you've started the PRA process, then build the form.
+1. To figure out if PRA applies to your form, first see if an exemption or generic clearance for common forms applies here:[https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
+2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/)In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more-basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed. 
+3. After you've started the PRA process, then build the form.
+4. Don't go it alone; get in touch with your agency's PRA contact. [https://pra.digital.gov/contact/](https://pra.digital.gov/contact/)
+
+### Privacy Act (PA)
+Add overview and link
+
+### Additional rules that may apply
+- The 21st Century IDEA Act applies to all executive agencies' public-facing websites. Use USDWS code to build your form found [here] (https://designsystem.digital.gov/components/form-templates/) and [here] (https://designsystem.digital.gov/components/form-controls/), which have important usability guidance baked right in.  
+- While the PRA and PA primarily focus on how data is collected, it is the [Federal Records Act] (https://www.archives.gov/records-mgmt/faqs/federal.html) that focus on how that data is stored or destroyed. Contact [X] to find out more.
+- If you will be collecting sensitive health data, fill in with overview and link. Contact [X] to find out more.
 
 ### Choosing a form service
 Federalist pages are static websites, there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,7 +4,7 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
-Do you need to ask questions of the people visiting your Federalist website? Do you need to ask for their contact info or let them give you feedback? You need a form. This page provides an overview of existing digital form tools and requirements so you can determine which best apply to your agency's situation and get started.
+Do you want to use a digital form to ask questions of the people visiting your Federalist website? Do you want them to fill out a form with their contact info or feedback? This page provides an overview of existing digital form tools and requirements so you can determine which best apply to your situation and get started.
 
 This pages covers:
 * [form services](#choosing-a-form-service)
@@ -15,7 +15,7 @@ Federalist pages are static websites. This means there is no backend for you to 
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms
-- Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
+- Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued. Your form users will also need access to Google Forms to be able to use your form.
 - Quick tips:
   * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
   * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
@@ -45,13 +45,13 @@ What it is: The Paperwork Reduction Act determines how federal agencies collect 
 
 Tip: If you do need to get PRA approval, publish a more basic version of your form that falls under a PRA exemption, and at the same time, [submit your full version for review](https://pra.digital.gov/clearance-process/). This will allow you to move forward while you wait for approval, which can take 6 to 9 months.
 
-How to get started: First figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
+How to get started: First [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 
 #### 508 Accessibility
 What it is: [Section 508 of the Rehabilitation Act of 1973](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) amplifies this accessibility, and requires a modern user experience.
 
 Tips:
-- Use the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) to design your form. It's built to help you more easily comply with accessibility. [Federalist templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS. To design the different parts of your form, refer to [USWDS form controls](https://designsystem.digital.gov/components/form-controls/). Pre-built [form templates](https://designsystem.digital.gov/components/form-templates/) offer great examples. Even if you use the USDWS, regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/).
+- Use the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) to design your form. It's built to help you more easily comply with accessibility. [Federalist templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS. To design the different parts of your form, refer to [USWDS form controls](https://designsystem.digital.gov/components/form-controls/). [Pre-built form templates](https://designsystem.digital.gov/components/form-templates/) offer great examples. Even if you use the USDWS, regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/).
 - If you create a form without using the USWDS, follow [18F's accessibility guide](https://accessibility.18f.gov/) to still ensure your form is accessible.
 - Follow these [plainlanguage guidelines](https://plainlanguage.gov/guidelines/) to ensure your content is accessible to the public.
 - Join the [Web Content Managers Forum](https://digital.gov/communities/web-content-managers/) to learn with others.
@@ -65,6 +65,11 @@ What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-19
   - Complete a Privacy Impact Assessment (PIA) to ensure that privacy issues and protections are addressed. Here is a [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf).
 
 How to get started: Get in contact with your agency's Privacy Office.
+
+#### Records Management
+What is is: The data collected in your form needs to be stored and destroyed in compliance with the Federal Records Act. You are responsible for identifying what of your data is considered a record, and managing those records in accordance with your agency's [National Archives and Records Administration (NARA)-approved record schedule](https://www.archives.gov/about/laws/fed-agencies.html).
+Tip: If your form data is considered a record, remember that the data collected in your form is stored in the forms service, not in Federalist.
+To get started: Get in touch with your agency's Records and Information Management (RIM) office.
 
 ## Want to learn more about Federalist or forms?
 Contact [Federalist product owners](x).

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,12 +4,11 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
-This page will help you choose what technology to use and how to navigate the compliance process for government forms.
+Looking to post a form to your Federalist site? This page provides an overview of existing form tools and requirements so you can determine which best apply to your situation and get started on your form.
 
-There are three sections in the page:
+This pages covers:
 * [Choosing a form service](#choosing-a-form-service)
 * [Form rules](#form-rules)
-* [Form tips](#form-tips)
 
 ## Choosing a form service
 Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some options:

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -18,8 +18,7 @@ Federalist pages are static websites; there is no backend for you to log into to
 - Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
 - Access: Federalist staff can help you determine if you are able to create a google account with [your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
 - Quick tips:
-* Google Forms has a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
-* [Limit submissions to users with a `.gov` or `.mil` email address] (https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform), see how in these [text validation instructions] (https://support.google.com/docs/answer/3378864?hl=en).
+* [Limit submissions to users with a `.gov` or `.mil` email address] (https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions] (https://support.google.com/docs/answer/3378864?hl=en).
 * Link one, or [multiple] (https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
 - To get started, do this/go here.
 

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -25,12 +25,12 @@ Add overview and link
 - While the PRA and PA primarily focus on how data is collected, it is the [Federal Records Act] (https://www.archives.gov/records-mgmt/faqs/federal.html) that focus on how that data is stored or destroyed. Contact [X] to find out more.
 - If you will be collecting sensitive health data, fill in with overview and link. Contact [X] to find out more.
 
-### Choosing a form service
-Federalist pages are static websites, there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.
+## Choosing a form service
+Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.
 
 - Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account.
-- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
-- Everything else - [Google Forms](https://gsuite.google.com/products/forms/). Google Forms can handle most all of your form needs. Below is more advice for Google Forms.
+- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey. This service costs X.
+- Everything else - [Google Forms](https://gsuite.google.com/products/forms/). Google Forms can handle most all of your form needs for free. Below is more advice for Google Forms.
 
 #### Google Forms
 Google Forms are easy to implement, secure, and customizable enough to handle whatever your form needs are. Here is advice on getting access to Google Forms and for adding them to your website with lots of examples.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -43,7 +43,7 @@ Several requirements may apply to your agency's digital form, whether posting to
 #### The Paperwork Reduction Act (PRA)
 What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: this [guide to the PRA](https://pra.digital.gov/) will help you understand if and how PRA is applicable to your form.
 
-Tip: If you do need to get PRA approval, publish a more basic version of your form that falls under a PRA exemption, and at the same time, [submit your full version for review]((https://pra.digital.gov/clearance-process/). This will allow you to move forward while you wait for approval, which can take 6 to 9 months.
+Tip: If you do need to get PRA approval, publish a more basic version of your form that falls under a PRA exemption, and at the same time, [submit your full version for review](https://pra.digital.gov/clearance-process/). This will allow you to move forward while you wait for approval, which can take 6 to 9 months.
 
 How to get started: First figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -1,0 +1,58 @@
+---
+title: Forms
+permalink: /documentation/forms/
+layout: page
+sidenav: documentation
+---
+
+When adding a form to your Federalist website, you need to answer two main questions:
+1. Does your form need to go through the Paperwork Reduction Act process?
+2. What technology will best serve your form's purpose?
+
+Forms in the Federal government have a lot of rules around what is allowed. This page will help you navigate those rules and help to choose what technology is appropriate.
+
+### The Paperwork Reduction Act (PRA)
+The PRA can be a complicated and lengthy process. It can take **6 to 9 months** to get a form approved for your website! Luckily, a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help your understanding of the PRA and its applicability to your form.
+
+1. Figure out if your form needs to go through the PRA process. There are a handful of exemptions. Also, some agencies have generic clearances in place for common forms already. [https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
+2. For help, get in touch with your agency's PRA contact. [https://pra.digital.gov/contact/](https://pra.digital.gov/contact/)
+3. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/)
+4. After you've started the PRA process, then build the form.
+
+### Choosing a form service
+Federalist pages are static websites, there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.
+
+- Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account.
+- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
+- Everything else - [Google Forms](https://gsuite.google.com/products/forms/). Google Forms can handle most all of your form needs. Below is more advice for Google Forms.
+
+#### Google Forms
+Google Forms are easy to implement, secure, and customizable enough to handle whatever your form needs are. Here is advice on getting access to Google Forms and for adding them to your website with lots of examples.
+
+<div class="usa-alert usa-alert-warning">
+  <div class="usa-alert-body">
+    <h3 class="usa-alert-heading">Some agencies can't use Google.</h3>
+    <p class="usa-alert-text">Some agencies have the Google Forms domains blocked on their office networks. Unfortunately these agencies will need to find another service to use.</p>
+  </div>
+</div>
+
+Most other agencies, while they may not have an official Google GSuite account purchased for use, can still usually get Google Forms another way.
+
+##### Options for getting access to Google Forms
+* Create a Google Account with your government email [using this form](https://accounts.google.com/SignUpWithoutGmail).
+* Federalist staff can help set you up a with GSA Affiliated Customer Account (GACA).
+* Get a special waiver from their own agency.
+
+##### Advice for using a Google Form
+Google Forms have a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
+
+The easiest way to include a Google Form on your page is to just link to it. Here is an [example](https://coe.gsa.gov/connect/contact-us.html#joinus) that links to a few different Google Forms.
+
+To maintain a consistent user experience and design for your forms, we recommend a more advanced technique though. You can write your own HTML form that posts the data to Google Forms. Here are some Federalist examples: [Example](https://tech.gsa.gov/work-with-us/#contact), [Example](https://www.afwerx.af.mil/join.html)
+
+Here is [a well written guide](https://blog.webjeda.com/google-form-customize/) for how to write your own HTML form that matches your created Google Form. You'll need to set your form's action url to post to the Google Form url, then set the correct name element for each of your form's questions. 
+
+#### USDWS advice
+If you are writing your own form HTML data, we recommend using the [United States Web Design System](https://designsystem.digital.gov/). Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
+- [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
+- A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/)

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -13,7 +13,7 @@ A number of rules may apply to your federal agency's digital form.
 The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if any how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
 
 1. To figure out if PRA applies to your form, first see if an exemption or generic clearance for common forms applies here: [https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
-2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/) In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more-basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
+2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/) In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
 3. After you've started the PRA process, then build the form.
 4. Don't go it alone; get in touch with your agency's PRA contact. [https://pra.digital.gov/contact/](https://pra.digital.gov/contact/)
 

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,7 +4,7 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
-This page will help you navigate form rules and choose what technology is appropriate.
+This page will help you navigate form rules and choose which technology is appropriate.
 
 ## Form rules
 A number of rules may apply to your federal agency's digital form. 
@@ -35,7 +35,7 @@ Federalist pages are static websites; there is no backend for you to log into to
 
 - Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account. [HubSpot](https://www.hubspot.com/) is another service used by Federalist customers.
 - Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
-- Contact forms, bug reporting, support requests - [Google Forms](https://gsuite.google.com/products/forms/). Google Forms can handle most of your form needs. Below is more advice for Google Forms.
+- Contact forms, bug reporting, support requests - [Google Forms](https://www.google.com/forms/about/). Google Forms can handle most of your form needs. Below is more advice for Google Forms.
 
 #### Google Forms
 Google Forms are easy to implement, secure, and customizable enough to handle whatever your form needs are. Here is advice on getting access to Google Forms and for adding them to your website with lots of examples.
@@ -55,7 +55,7 @@ Other agencies, while they may not have an official Google GSuite account purcha
 * Get a special waiver from your own agency.
 
 ##### Advice for using a Google Form
-* Google Forms have a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
-* Text fields have a validation option explained [here](https://support.google.com/docs/answer/3378864?hl=en). This can be used to limit submissions to users with a `.gov` or `.mil` email address, as in this [example](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform).
+* Google Forms has a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
+* The validation options for text fields are explained [here](https://support.google.com/docs/answer/3378864?hl=en). This can be used to limit submissions to users with a `.gov` or `.mil` email address, as in this [example](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform).
 * The easiest way to include a Google Form on your page is to just link to it. Here is an [example](https://coe.gsa.gov/connect/contact-us.html#joinus) that links to a few different Google Forms.
 * A more advanced technique is to write your own HTML form that posts the data directly to Google Forms. Here are some Federalist examples: [Example](https://tech.gsa.gov/work-with-us/#contact), [Example](https://www.afwerx.af.mil/join.html). This lets you maintain a consistent user experience and design for your forms.  Here is [a well written guide](https://blog.webjeda.com/google-form-customize/) for how to write your own HTML form that matches your created Google Form. You'll need to set your form's action url to post to the Google Form url, then set the correct name element for each of your form's questions. Good luck!

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,7 +4,19 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
-This page will help you navigate form rules and choose which technology is appropriate.
+This page will help you choose what technology to use and how to navigate the compliance process for government forms.
+
+There are three sections in the page:
+* [Choosing a form service](#choosing-a-form-service)
+* [Form rules](#form-rules)
+* [Other tips](#other-tips)
+
+## Choosing a form service
+Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some options:
+
+- Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account. [HubSpot](https://www.hubspot.com/) is another service used by Federalist customers.
+- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
+- Contact forms, bug reporting, support requests - [Google Forms](https://www.google.com/forms/about/). Google Forms can handle most of your form needs. Below is more advice for Google Forms.
 
 ## Form rules
 A number of rules may apply to your federal agency's digital form. 
@@ -30,13 +42,8 @@ Any forms collecting Personally Identifiable Information (PII) will have to comp
 #### SORN
 The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agency publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
 
-## Choosing a form service
-Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.
 
-- Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account. [HubSpot](https://www.hubspot.com/) is another service used by Federalist customers.
-- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
-- Contact forms, bug reporting, support requests - [Google Forms](https://www.google.com/forms/about/). Google Forms can handle most of your form needs. Below is more advice for Google Forms.
-
+## Other tips
 #### Google Forms
 Google Forms are easy to implement, secure, and customizable enough to handle whatever your form needs are. Here is advice on getting access to Google Forms and for adding them to your website with lots of examples.
 

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -40,33 +40,38 @@ Federalist pages are static websites. This means there is no backend for you to 
 ## Form requirements
 Several requirements may apply to your agency's digital form, whether posting to Federalist or another site.
 
-#### The Paperwork Reduction Act (PRA)
-What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: this [guide to the PRA](https://pra.digital.gov/) will help you understand if and how PRA is applicable to your form.
+#### [The Paperwork Reduction Act (PRA)](https://digital.gov/resources/paperwork-reduction-act-44-u-s-c-3501-et-seq/)
+What it is: The PRA determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: this [guide to the PRA](https://pra.digital.gov/) will help you understand if and how PRA is applicable to your form.
 
 Tip: If you do need to get PRA approval, publish a more basic version of your form that falls under a PRA exemption, and at the same time, [submit your full version for review](https://pra.digital.gov/clearance-process/). This will allow you to move forward while you wait for approval, which can take 6 to 9 months.
 
 How to get started: First [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 
 #### OMB Circular A-11
+What it is:
+Tip:
+To get started:
 
-#### 508 Accessibility
-What it is: [Section 508 of the Rehabilitation Act of 1973](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) amplifies this accessibility, and requires a modern user experience.
+#### [Section 508 of the Rehabilitation Act of 1973 (508 Compliance)](https://www.section508.gov/manage/laws-and-policies)
+What it is: 508 compliance requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) amplifies this accessibility, and requires a modern user experience.
 
 Tips:
 - Use the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) to design your form. It's built to help you more easily comply with accessibility. [Federalist templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS. To design the different parts of your form, refer to [USWDS form controls](https://designsystem.digital.gov/components/form-controls/). [Pre-built form templates](https://designsystem.digital.gov/components/form-templates/) offer great examples. Even if you use the USDWS, regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/).
 - If you create a form without using the USWDS, follow [18F's accessibility guide](https://accessibility.18f.gov/) to still ensure your form is accessible.
 - Follow these [plainlanguage guidelines](https://plainlanguage.gov/guidelines/) to ensure your content is accessible to the public.
-- Join the [Web Content Managers Forum](https://digital.gov/communities/web-content-managers/) to learn with others.
 
 To get started: X. 
 
-#### Privacy Act
-What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html) requires the government to keep track of any forms collecting Personally Identifiable Information (PII), to keep that information secure, and in some cases, complete a Privacy Impact Assessment (PIA), like this [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf). Each agency is responsible for assessing the need for an official System of Record Notice (SORN) for information collected via Forms. A list of SORNs should be available in each agency, like [GSA's list of SORNs](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act). If an agency determines it needs a SORN, it must also create and add a Privacy Act Notice to its Form.
+#### [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html)
+What it is: The Privacy Act requires the government to keep track of any forms collecting Personally Identifiable Information (PII), to keep that information secure, and in some cases, complete a Privacy Impact Assessment (PIA), like this [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf). Each agency is responsible for assessing the need for an official System of Record Notice (SORN) for information collected via Forms. A list of SORNs should be available in each agency, like [GSA's list of SORNs](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act). If an agency determines it needs a SORN, it must also create and add a Privacy Act Notice to its Form.
 Tip: If you are required to include a Privacy Act Notice in your form, find out if your agency has a stock language you can link to on your form. Check out [Department of Homeland Security's (DHS) Privacy Act Notice template](https://www.dhs.gov/xlibrary/assets/privacy/privacy_guidance_e3.pdf) for an example. For GSA users, here is [GSA's Privacy and Security Notice](https://www.gsa.gov/website-information/privacy-and-security-notice) to use. 
 
 How to get started: Get in contact with your agency's Privacy Office. GSA users should start by filling out the [GSA Privacy Office intake form](https://docs.google.com/forms/d/1fYME9MzhfAYuRiONJEsf1EFS9cmg03jODFq2Y9hkEgs/viewform?edit_requested=true).
 
-#### Records Management
+#### [Federal Records Act](https://www.archives.gov/about/laws/fed-agencies.html)
 What is is: The data collected in your form needs to be stored and destroyed in compliance with the Federal Records Act. You are responsible for identifying what of your data is considered a record, and managing those records in accordance with your agency's [National Archives and Records Administration (NARA)-approved record schedule](https://www.archives.gov/about/laws/fed-agencies.html).
 Tip: If your form data is considered a record, remember that the data collected in your form is stored in the forms service, not in Federalist.
 To get started: Get in touch with your agency's Records and Information Management (RIM) office.
+
+## Want to learn from other agencies using digital forms?
+Join the [Web Content Managers Forum](https://digital.gov/communities/web-content-managers/).

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -1,5 +1,5 @@
 ---
-title: Forms
+title: Forms on Federalist sites
 permalink: /documentation/forms/
 layout: page
 sidenav: documentation
@@ -10,8 +10,8 @@ This pages covers:
 * [Choosing a form service](#choosing-a-form-service)
 * [Form requirements](#form-requirements)
 
-## Choosing a form service
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency's form data. You'll need to use a separate form service to use a digital form on your agency's site. Choosing a service depends on the purpose of your agency's form.
+## Form services
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers identified through research funded by GSA's 10x program. This list is continuously updated, please contact [Federalist product owners](x) if you see other service providers that should be added.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms
@@ -20,48 +20,43 @@ Federalist pages are static websites. This means there is no backend for you to 
   * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
   * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
   * If you need to include government employees whose agency has blocked Google services, provide an alternative submission method, such as an email address.
-- To get started: Talk to Federalist staff to find out if your agency allows access to Google services.
+- To get started: Talk to [Federalist product owners](x) to find out if your agency allows access to Google services.
 
 #### [GovDelivery](https://granicus.com/solution/govdelivery/)
-- Use cases: Newsletter sign ups
-- Access: Available for GSA; fully 508 compliant and FedRAMP certified.
-- To get started: Check this [FedRamp link](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery) to see if your agency has access. Talk to your Chief Information Security Office (CISO) to get an account.
+- Use cases: Newsletter sign ups.
+- Access: Available for GSA; fully 508 compliant and FedRAMP certified. Other agencies with access listed at the [FedRamp marketplace](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery).
+- To get started:  Talk to your Chief Information Security Office (CISO) to get an account.
 
 #### [HubSpot](https://www.hubspot.com/)
-- Use cases: sign ups
-- Access: Available for GSA.
-- To get started: Talk to your agency's CISO office to find out if you have access and can get an account.
+- Use cases: Newsletter sign ups.
+- Access: Available for GSA. May be available for other agencies.
+- To get started: Talk to your CISO to find out if you have access.
 
 #### [Touchpoints](https://feedback.usa.gov/touchpoints/)
 - Use cases: standardized feedback and contact forms, custom forms
 - Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
-- To get started: Visit [https://feedback.usa.gov/touchpoints/](https://feedback.usa.gov/touchpoints/)
+- To get started: Visit the [Touchpoints homepage](https://feedback.usa.gov/touchpoints/) to learn more.
 
 ## Form requirements
-Here are some requirements that may apply to your agency's digital form. These compliance needs apply to any form, wether they are on Federalist or not.
+Several requirements may apply to your agency's digital form, whether posting to Federalist or another site.
 
 #### The Paperwork Reduction Act (PRA)
-What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: [a fantastic guide](https://pra.digital.gov/) has been written to help you understand if and how PRA is applicable to your form.
+What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: this [guide to the PRA](https://pra.digital.gov/) will help you understand if and how PRA is applicable to your form.
 
-When it applies: To [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/), first see if an exemption or generic clearance for common forms applies.
+Tip: If you do need to get PRA approval, publish a more basic version of your form that falls under a PRA exemption, and at the same time, [submit your full version for review]((https://pra.digital.gov/clearance-process/). This will allow you to move forward while you wait for approval, which can take 6 to 9 months.
 
-Tips: If you do need to get PRA approval, then start early! In some cases it can take 6 to 9 months to [get a form approved](https://pra.digital.gov/clearance-process/) for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
-
-How to get started: Get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
-
+How to get started: First figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 
 #### 508 Accessibility
-What it is: [Section 508](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) reinforces this accessibility, and requires a modern user experience.
+What it is: [Section 508 of the Rehabilitation Act of 1973](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) amplifies this accessibility, and requires a modern user experience.
 
-Tips: We recommend using the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) for your form. Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
-  - [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
-  - A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/).
+Tips:
+- Use the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) to design your form. It's built to help you more easily comply with accessibility. [Federalist templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS. To design the different parts of your form, refer to [USWDS form controls](https://designsystem.digital.gov/components/form-controls/). Pre-built [form templates](https://designsystem.digital.gov/components/form-templates/) offer great examples. Even if you use the USDWS, regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/).
+- If you create a form without using the USWDS, follow [18F's accessibility guide](https://accessibility.18f.gov/) to still ensure your form is accessible.
+- Follow these [plainlanguage guidelines](https://plainlanguage.gov/guidelines/) to ensure your content is accessible to the public.
+- Join the [Web Content Managers Forum](https://digital.gov/communities/web-content-managers/) to learn with others.
 
-The USWDS is built to more easily comply with accessibility. It is still best practice to regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/). If you end up creating a form without using the USWDS, you'll need to do the work to make your form accessible. Use [https://accessibility.18f.gov/](https://accessibility.18f.gov/) as a guide.
-
-Another best practice is to write your content in a way that is accessible for the public. [Guidelines available at plainlanguage.gov](https://plainlanguage.gov/guidelines/)
-
-To talk to others, join the [Web Content Managers Forum](https://digital.gov/communities/web-content-managers/).
+To get started: X. 
 
 #### Privacy Act
 What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html) requires the government to keep track of any forms collecting Personally Identifiable Information (PII) and to help keep that information secure. If your form is collecting PII from the public, you'll most likely need to:
@@ -70,3 +65,6 @@ What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-19
   - Complete a Privacy Impact Assessment (PIA) to ensure that privacy issues and protections are addressed. Here is a [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf).
 
 How to get started: Get in contact with your agency's Privacy Office.
+
+## Want to learn more about Federalist or forms?
+Contact [Federalist product owners](x).

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -11,7 +11,7 @@ This pages covers:
 * [Form requirements](#form-requirements)
 
 ## Form services
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact [Federalist product owners](x) if you see other service providers that should be added.
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact [Federalist product owners](federalist-support@gsa.gov) if you see other service providers that should be added.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -11,30 +11,30 @@ This pages covers:
 * [Form requirements](#form-requirements)
 
 ## Form services
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact [Federalist product owners](federalist-support@gsa.gov) if you see other service providers that should be added.
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers, identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact [Federalist product owners](federalist-support@gsa.gov) if you see other service providers that should be added.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms
-- Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued. Your form users will also need access to Google Forms to be able to use your form.
+- Access: Available when you [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; your agency may be able to issue you a special waiver for Google GSuite access.
 - Quick tips:
   * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
   * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
-  * If you need to include government employees whose agency has blocked Google services, provide an alternative submission method, such as an email address.
-- To get started: Talk to [Federalist product owners](x) to find out if your agency allows access to Google services.
+  * Keep in mind your form users need to have access to Google GSuite too. If you need to include users who are blocked, post an email address to where they can request a PDF form instead.
+- To get started: See if you can [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail). If not, try to open this [test form](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform). If you can't, your agency likely fully blocks access to Google Forms. Ask your Office of the Chief Information Officer about acquiring a special waiver.
 
 #### [GovDelivery](https://granicus.com/solution/govdelivery/)
 - Use cases: Newsletter sign ups.
-- Access: Available for GSA; fully 508 compliant and FedRAMP certified. Other agencies with access listed at the [FedRamp marketplace](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery).
-- To get started:  Talk to your Chief Information Security Office (CISO) to get an account.
+- Access: Available for GSA; fully 508 compliant and FedRAMP certified. Other agencies with access are listed at the [FedRamp marketplace](https://marketplace.fedramp.gov/#/product/govdelivery-communications-cloud?sort=productName&productNameSearch=govdelivery).
+- To get started:  Once you've checked your agency has access, talk to your Office of the Chief Information Officer to get an account.
 
 #### [HubSpot](https://www.hubspot.com/)
 - Use cases: Newsletter sign ups.
 - Access: Available for GSA. May be available for other agencies.
-- To get started: Talk to your CISO to find out if you have access.
+- To get started: Talk to your Office of the Chief Information Officer to find out if you have access.
 
 #### [Touchpoints](https://feedback.usa.gov/touchpoints/)
 - Use cases: standardized feedback and contact forms, custom forms
-- Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
+- Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval and conform to OMB's Circular A-11 requirements. Additional approval may be required for custom forms.
 - To get started: Visit the [Touchpoints homepage](https://feedback.usa.gov/touchpoints/) to learn more.
 
 ## Form requirements
@@ -46,6 +46,8 @@ What it is: The Paperwork Reduction Act determines how federal agencies collect 
 Tip: If you do need to get PRA approval, publish a more basic version of your form that falls under a PRA exemption, and at the same time, [submit your full version for review](https://pra.digital.gov/clearance-process/). This will allow you to move forward while you wait for approval, which can take 6 to 9 months.
 
 How to get started: First [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
+
+#### OMB Circular A-11
 
 #### 508 Accessibility
 What it is: [Section 508 of the Rehabilitation Act of 1973](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) amplifies this accessibility, and requires a modern user experience.
@@ -59,17 +61,12 @@ Tips:
 To get started: X. 
 
 #### Privacy Act
-What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html) requires the government to keep track of any forms collecting Personally Identifiable Information (PII) and to help keep that information secure. If your form is collecting PII from the public, you'll most likely need to:
-  - Include Privacy Act Notice language with the relevant form. Here is [GSA's Privacy and Security Notice](https://www.gsa.gov/website-information/privacy-and-security-notice), which is linked to from each form on GSA's website.
-  - Ensure the form tool you are using has an official System of Record Notice (SORN). Here is the list of [GSA's SORNs for reference](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act).
-  - Complete a Privacy Impact Assessment (PIA) to ensure that privacy issues and protections are addressed. Here is a [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf).
+What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html) requires the government to keep track of any forms collecting Personally Identifiable Information (PII), to keep that information secure, and in some cases, complete a Privacy Impact Assessment (PIA), like this [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf). Each agency is responsible for assessing the need for an official System of Record Notice (SORN) for information collected via Forms. A list of SORNs should be available in each agency, like [GSA's list of SORNs](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act). If an agency determines it needs a SORN, it must also create and add a Privacy Act Notice to its Form.
+Tip: If you are required to include a Privacy Act Notice in your form, find out if your agency has a stock language you can link to on your form. Check out [Department of Homeland Security's (DHS) Privacy Act Notice template](https://www.dhs.gov/xlibrary/assets/privacy/privacy_guidance_e3.pdf) for an example. For GSA users, here is [GSA's Privacy and Security Notice](https://www.gsa.gov/website-information/privacy-and-security-notice) to use. 
 
-How to get started: Get in contact with your agency's Privacy Office.
+How to get started: Get in contact with your agency's Privacy Office. GSA users should start by filling out the [GSA Privacy Office intake form](https://docs.google.com/forms/d/1fYME9MzhfAYuRiONJEsf1EFS9cmg03jODFq2Y9hkEgs/viewform?edit_requested=true).
 
 #### Records Management
 What is is: The data collected in your form needs to be stored and destroyed in compliance with the Federal Records Act. You are responsible for identifying what of your data is considered a record, and managing those records in accordance with your agency's [National Archives and Records Administration (NARA)-approved record schedule](https://www.archives.gov/about/laws/fed-agencies.html).
 Tip: If your form data is considered a record, remember that the data collected in your form is stored in the forms service, not in Federalist.
 To get started: Get in touch with your agency's Records and Information Management (RIM) office.
-
-## Want to learn more about Federalist or forms?
-Contact [Federalist product owners](x).

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -9,14 +9,34 @@ This page will help you choose what technology to use and how to navigate the co
 There are three sections in the page:
 * [Choosing a form service](#choosing-a-form-service)
 * [Form rules](#form-rules)
-* [Other tips](#other-tips)
+* [Form tips](#form-tips)
 
 ## Choosing a form service
 Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some options:
 
-- Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account. [HubSpot](https://www.hubspot.com/) is another service used by Federalist customers.
-- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
-- Contact forms, bug reporting, support requests - [Google Forms](https://www.google.com/forms/about/). Google Forms can handle most of your form needs. Below is more advice for Google Forms.
+[Google Forms](https://www.google.com/forms/about/)
+- Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
+- Access: Federalist staff can help you determine if you are able to create a google account with [your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
+- Quick tips:
+* Google Forms has a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
+* [Limit submissions to users with a `.gov` or `.mil` email address] (https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform), see how in these [text validation instructions] (https://support.google.com/docs/answer/3378864?hl=en).
+* Link one, or [multiple] (https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
+- To get started, do this/go here.
+
+[GovDelivery](https://granicus.com/solution/govdelivery/)
+- Use cases: sign ups
+- Access: Available for GSA; fully 508 compliant and FedRAMP certified. For others, check with your agency's X group. 
+- To get started, do this/go here.
+
+[HubSpot](https://www.hubspot.com/)
+- Use cases: sign ups
+- Access: Available for GSA. For others, check with your agency's X group.
+- To get started, do this/go here.
+
+[Touchpoints](https://touchpoints.digital.gov)
+- Use cases: standardized feedback and contact forms, custom forms
+- Access: Available for all federal agencies with associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
+- To get started, do this/go here.
 
 ## Form rules
 A number of rules may apply to your federal agency's digital form. 
@@ -41,28 +61,3 @@ Any forms collecting Personally Identifiable Information (PII) will have to comp
 
 #### SORN
 The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agency publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
-
-
-## Other tips
-#### Google Forms
-Google Forms are easy to implement, secure, and customizable enough to handle whatever your form needs are. Here is advice on getting access to Google Forms and for adding them to your website with lots of examples.
-
-<div class="usa-alert usa-alert-warning">
-  <div class="usa-alert-body">
-    <h3 class="usa-alert-heading">Some agencies can't use Google.</h3>
-    <p class="usa-alert-text">Some agencies have the Google Forms domains blocked on their office networks. Unfortunately these agencies will need to find another service to use.</p>
-  </div>
-</div>
-
-Other agencies, while they may not have an official Google GSuite account purchased for use, can still usually get Google Forms another way.
-
-##### Options for getting access to Google Forms
-* Create a Google Account with [your government email](https://accounts.google.com/SignUpWithoutGmail).
-* Federalist staff can help set you up a with GSA Affiliated Customer Account (GACA). Instructions for Federalist staff are behind the GSA firewall [here](https://insite.gsa.gov/node/118179?term=gaca).
-* Get a special waiver from your own agency.
-
-##### Advice for using a Google Form
-* Google Forms has a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
-* The validation options for text fields are explained [here](https://support.google.com/docs/answer/3378864?hl=en). This can be used to limit submissions to users with a `.gov` or `.mil` email address, as in this [example](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform).
-* The easiest way to include a Google Form on your page is to just link to it. Here is an [example](https://coe.gsa.gov/connect/contact-us.html#joinus) that links to a few different Google Forms.
-* A more advanced technique is to write your own HTML form that posts the data directly to Google Forms. Here are some Federalist examples: [Example](https://tech.gsa.gov/work-with-us/#contact), [Example](https://www.afwerx.af.mil/join.html). This lets you maintain a consistent user experience and design for your forms.  Here is [a well written guide](https://blog.webjeda.com/google-form-customize/) for how to write your own HTML form that matches your created Google Form. You'll need to set your form's action url to post to the Google Form url, then set the correct name element for each of your form's questions. Good luck!

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -7,11 +7,11 @@ sidenav: documentation
 Do you need to ask questions of the people visiting your Federalist website? Do you need to ask for their contact info or let them give you feedback? You need a form. This page provides an overview of existing digital form tools and requirements so you can determine which best apply to your agency's situation and get started.
 
 This pages covers:
-* [Choosing a form service](#choosing-a-form-service)
+* [form services](#choosing-a-form-service)
 * [Form requirements](#form-requirements)
 
 ## Form services
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers identified through research funded by GSA's 10x program. This list is continuously updated, please contact [Federalist product owners](x) if you see other service providers that should be added.
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact [Federalist product owners](x) if you see other service providers that should be added.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -11,11 +11,11 @@ This pages covers:
 * [Form requirements](#form-requirements)
 
 ## Form services
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers, identified through research funded by [GSA's 10x program](https://18f.gsa.gov/tags/10x/). This list is continuously updated, please contact Federalist product owners at federalist-support@gsa.gov if you see other service providers that should be added.
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency’s form data. You’ll need to use a separate form service to use a digital form on your agency’s site. Below is a list of service providers, identified through research funded by [GSA's 10x program](https://10x.gsa.gov/). This list is continuously updated, please [suggest an addition](https://github.com/18F/federalist.18f.gov/issues) if you know other form services in use on Federalist.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms
-- Access: Available when you [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; your agency may be able to issue you a special waiver for Google GSuite access.
+- Access: Your agency may already use Google services. If not, Federalist staff can assist you in creating a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms though; your agency may be able to issue you a special waiver for Google GSuite access.
 - Quick tips:
   * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
   * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
@@ -47,30 +47,28 @@ Tip: If you do need to get PRA approval, publish a more basic version of your fo
 
 How to get started: First [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/) or if an exemption or generic clearance applies to your situation. Also, get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 
-#### OMB Circular A-11
-What it is:
-Tip:
-To get started:
-
 #### [Section 508 of the Rehabilitation Act of 1973 (508 Compliance)](https://www.section508.gov/manage/laws-and-policies)
 What it is: 508 compliance requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) amplifies this accessibility, and requires a modern user experience.
 
 Tips:
 - Use the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) to design your form. It's built to help you more easily comply with accessibility. [Federalist templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS. To design the different parts of your form, refer to [USWDS form controls](https://designsystem.digital.gov/components/form-controls/). [Pre-built form templates](https://designsystem.digital.gov/components/form-templates/) offer great examples. Even if you use the USDWS, regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/).
-- If you create a form without using the USWDS, follow [18F's accessibility guide](https://accessibility.18f.gov/) to still ensure your form is accessible.
+- If you create a form without using the USWDS, follow [18F's accessibility guide for forms](https://accessibility.18f.gov/forms/) to still ensure your form is accessible.
 - Follow these [plainlanguage guidelines](https://plainlanguage.gov/guidelines/) to ensure your content is accessible to the public.
 
-To get started: X. 
+To get started: Use the USWDS to design your site. Regularly scan your site for accessibility. Contact the [508 Access Board](https://www.access-board.gov/guidelines-and-standards/communications-and-it/about-the-section-508-standards/section-508-standards) for technical assistance . 
 
 #### [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html)
-What it is: The Privacy Act requires the government to keep track of any forms collecting Personally Identifiable Information (PII), to keep that information secure, and in some cases, complete a Privacy Impact Assessment (PIA), like this [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf). Each agency is responsible for assessing the need for an official System of Record Notice (SORN) for information collected via Forms. A list of SORNs should be available in each agency, like [GSA's list of SORNs](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act). If an agency determines it needs a SORN, it must also create and add a Privacy Act Notice to its Form.
+What it is: The Privacy Act requires the government to keep track of any forms collecting Personally Identifiable Information (PII), to keep that information secure, and in some cases, complete a Privacy Impact Assessment (PIA), like this [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf). Each agency is responsible for assessing the need for an official System of Record Notice (SORN) for information collected via Forms. A list of SORNs should be available in each agency, like [GSA's list of SORNs](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act). If an agency determines it needs a SORN, it must also create and add a Privacy Act Notice to its form.
+
 Tip: If you are required to include a Privacy Act Notice in your form, find out if your agency has a stock language you can link to on your form. Check out [Department of Homeland Security's (DHS) Privacy Act Notice template](https://www.dhs.gov/xlibrary/assets/privacy/privacy_guidance_e3.pdf) for an example. For GSA users, here is [GSA's Privacy and Security Notice](https://www.gsa.gov/website-information/privacy-and-security-notice) to use. 
 
 How to get started: Get in contact with your agency's Privacy Office. GSA users should start by filling out the [GSA Privacy Office intake form](https://docs.google.com/forms/d/1fYME9MzhfAYuRiONJEsf1EFS9cmg03jODFq2Y9hkEgs/viewform?edit_requested=true).
 
 #### [Federal Records Act](https://www.archives.gov/about/laws/fed-agencies.html)
 What is is: The data collected in your form needs to be stored and destroyed in compliance with the Federal Records Act. You are responsible for identifying what of your data is considered a record, and managing those records in accordance with your agency's [National Archives and Records Administration (NARA)-approved record schedule](https://www.archives.gov/about/laws/fed-agencies.html).
+
 Tip: If your form data is considered a record, remember that the data collected in your form is stored in the forms service, not in Federalist.
+
 To get started: Get in touch with your agency's Records and Information Management (RIM) office.
 
 ## Want to learn from other agencies using digital forms?

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -4,14 +4,14 @@ permalink: /documentation/forms/
 layout: page
 sidenav: documentation
 ---
-Looking to post a form to your Federalist site? This page provides an overview of existing form tools and requirements so you can determine which best apply to your situation and get started on your form.
+Looking to post a digital form to your federal agency's Federalist site? This page provides an overview of existing ditigal form tools and requirements so you can determine which best apply to your agency's situation and get started.
 
 This pages covers:
 * [Choosing a form service](#choosing-a-form-service)
-* [Form rules](#form-rules)
+* [Form requirements](#form-requirements)
 
 ## Choosing a form service
-Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some options:
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency's form data. You'll need to use a separate form service to use a digital form on your agency's site. Choosing a service depends on what the purpose of your agency's form is. Here are some options:
 
 [Google Forms](https://www.google.com/forms/about/)
 - Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
@@ -36,8 +36,8 @@ Federalist pages are static websites; there is no backend for you to log into to
 - Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
 - To get started, do this/go here.
 
-## Form rules
-A number of rules may apply to your federal agency's digital form. 
+## Form requirements
+Here are some requirements that may apply to your agency's digital form. 
 
 ### The Paperwork Reduction Act (PRA)
 The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if and how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -11,7 +11,7 @@ This pages covers:
 * [Form requirements](#form-requirements)
 
 ## Choosing a form service
-Federalist pages are static websites. This means there is no backend for you to log into to get your agency's form data. You'll need to use a separate form service to use a digital form on your agency's site. Choosing a service depends on what the purpose of your agency's form is. Here are some options:
+Federalist pages are static websites. This means there is no backend for you to log into to get your agency's form data. You'll need to use a separate form service to use a digital form on your agency's site. Choosing a service depends on the purpose of your agency's form.
 
 #### [Google Forms](https://www.google.com/forms/about/)
 - Use cases: Newsletter sign ups, contact us, feedback, bug reporting, support requests, other custom forms
@@ -30,32 +30,43 @@ Federalist pages are static websites. This means there is no backend for you to 
 #### [HubSpot](https://www.hubspot.com/)
 - Use cases: sign ups
 - Access: Available for GSA. For others, check with your agency's X group.
-- To get started, do this/go here.
+- To get started: Talk to your agency's CISO office to find out if you have access.
 
-#### [Touchpoints](https://touchpoints.digital.gov)
+#### [Touchpoints](https://feedback.usa.gov/touchpoints/)
 - Use cases: standardized feedback and contact forms, custom forms
 - Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
-- To get started, do this/go here.
+- To get started: Visit [https://feedback.usa.gov/touchpoints/](https://feedback.usa.gov/touchpoints/)
 
 ## Form requirements
-Here are some requirements that may apply to your agency's digital form. 
+Here are some requirements that may apply to your agency's digital form. These compliance needs apply to any form, wether they are on Federalist or not.
 
 #### The Paperwork Reduction Act (PRA)
-* What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: [a fantastic guide](https://pra.digital.gov/) has been written to help you understand if and how PRA is applicable to your form. 
-* When it applies: To [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/), first see if an exemption or generic clearance for common forms applies.
-* Tips: If you do need to get PRA approval, then start early! In some cases it can take 6 to 9 months to [get a form approved](https://pra.digital.gov/clearance-process/) for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
-* How to get started: Get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
+What it is: The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: [a fantastic guide](https://pra.digital.gov/) has been written to help you understand if and how PRA is applicable to your form.
+
+When it applies: To [figure out if PRA applies to your form](https://pra.digital.gov/do-i-need-clearance/), first see if an exemption or generic clearance for common forms applies.
+
+Tips: If you do need to get PRA approval, then start early! In some cases it can take 6 to 9 months to [get a form approved](https://pra.digital.gov/clearance-process/) for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
+
+How to get started: Get in touch with your agency's [PRA contact](https://pra.digital.gov/contact/).
 
 
 #### 508 Accessibility
-What it is: [508](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) reinforces this accessibility, and requires a modern user experience.
-Tips: We recommend using the [United States Web Design System](https://designsystem.digital.gov/) for your form. Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
-- [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
-- A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/).
+What it is: [Section 508](https://www.section508.gov/manage/laws-and-policies) requires that government websites be fully accessible to people with disabilities. The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) reinforces this accessibility, and requires a modern user experience.
 
-The USWDS has ben built to include accessibility and modern web design. It is still best practice to [scan for accessibility compliance](https://accessibility.18f.gov/tools/). If you end up creating a form without using the USWDS, you'll need to do the work to make your form accessible. Use [https://accessibility.18f.gov/](https://accessibility.18f.gov/) as a guide.
+Tips: We recommend using the [United States Web Design System](https://designsystem.digital.gov/) (USWDS) for your form. Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
+  - [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
+  - A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/).
+
+The USWDS is built to more easily comply with accessibility. It is still best practice to regularly [scan for accessibility compliance](https://accessibility.18f.gov/tools/). If you end up creating a form without using the USWDS, you'll need to do the work to make your form accessible. Use [https://accessibility.18f.gov/](https://accessibility.18f.gov/) as a guide.
+
+Another best practice is to write your content in a way that is accessible for the public. [Guidelines available at plainlanguage.gov](https://plainlanguage.gov/guidelines/)
+
+To talk to others, join the [Web Content Managers Forum](https://digital.gov/communities/web-content-managers/).
 
 #### Privacy Act
-What it is: https://www.archives.gov/about/laws/privacy-act-1974.html
+What it is: The [Privacy Act](https://www.archives.gov/about/laws/privacy-act-1974.html) requires the government to keep track of any forms collecting Personally Identifiable Information (PII) and to help keep that information secure. If your form is collecting PII from the public, you'll most likely need to:
+  - Include Privacy Act Notice language with the relevant form. Here is [GSA's Privacy and Security Notice](https://www.gsa.gov/website-information/privacy-and-security-notice), which is linked to from each form on GSA's website.
+  - Ensure the form tool you are using has an official System of Record Notice (SORN). Here is the list of [GSA's SORNs for reference](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act).
+  - Complete a Privacy Impact Assessment (PIA) to ensure that privacy issues and protections are addressed. Here is a [PIA written for GovDelivery by the Department of the Interior](https://www.doi.gov/sites/doi.gov/files/uploads/govdelivery_pia_final_05.31.2017_1.pdf).
 
-Any forms collecting Personally Identifiable Information (PII) will have to comply with their agency's Privacy process. Here is GSA's for reference: [https://before-you-ship.18f.gov/privacy/](https://before-you-ship.18f.gov/privacy/). The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agency publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
+How to get started: Get in contact with your agency's Privacy Office.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -51,7 +51,7 @@ Other agencies, while they may not have an official Google GSuite account purcha
 
 ##### Options for getting access to Google Forms
 * Create a Google Account with [your government email](https://accounts.google.com/SignUpWithoutGmail).
-* Federalist staff can help set you up a with GSA Affiliated Customer Account (GACA).
+* Federalist staff can help set you up a with GSA Affiliated Customer Account (GACA). Instructions for Federalist staff are behind the GSA firewall [here](https://insite.gsa.gov/node/118179?term=gaca).
 * Get a special waiver from your own agency.
 
 ##### Advice for using a Google Form

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -33,7 +33,7 @@ Federalist pages are static websites; there is no backend for you to log into to
 
 [Touchpoints](https://touchpoints.digital.gov)
 - Use cases: standardized feedback and contact forms, custom forms
-- Access: Available for all federal agencies with associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
+- Access: Available for all federal agencies, including access to Touchpoint's associated generic clearance. Standardized forms include fast track Paperwork Reduction Act (PRA) approval. Additional approval may be required for custom forms.
 - To get started, do this/go here.
 
 ## Form rules

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -18,8 +18,8 @@ Federalist pages are static websites; there is no backend for you to log into to
 - Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
 - Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
 - Quick tips:
-* [Limit submissions to users with a `.gov` or `.mil` email address] (https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions] (https://support.google.com/docs/answer/3378864?hl=en).
-* Link one, or [multiple] (https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
+* [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
+* Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
 - To get started, do this/go here.
 
 [GovDelivery](https://granicus.com/solution/govdelivery/)

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -19,7 +19,7 @@ Federalist pages are static websites. This means there is no backend for you to 
 - Quick tips:
   * [Limit submissions to users with a `.gov` or `.mil` email address](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions](https://support.google.com/docs/answer/3378864?hl=en).
   * Link one, or [multiple](https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.
-  * Some agencies block Google forms, so if you need government employees to answer provide and alternative, such as an email address.
+  * If you need to include government employees whose agency has blocked Google services, provide an alternative submission method, such as an email address.
 - To get started: Talk to Federalist staff to find out if your agency allows access to Google services.
 
 #### [GovDelivery](https://granicus.com/solution/govdelivery/)

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -16,7 +16,7 @@ Federalist pages are static websites; there is no backend for you to log into to
 
 [Google Forms](https://www.google.com/forms/about/)
 - Use cases: sign ups, contact us, feedback, bug reporting, support requests, data filtering, other custom forms
-- Access: Federalist staff can help you determine if you are able to create a google account with [your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
+- Access: Federalist staff can help you determine if you are able to [create a google account with your government email](https://accounts.google.com/SignUpWithoutGmail) or create a GSA Affiliated Customer Account (GACA). Some agencies are fully blocked from using Google Forms; check with your agency if a special waiver for Google GSuite access may be issued.
 - Quick tips:
 * [Limit submissions to users with a `.gov` or `.mil` email address] (https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform) or certain agency affiliation, see how in these [text validation instructions] (https://support.google.com/docs/answer/3378864?hl=en).
 * Link one, or [multiple] (https://coe.gsa.gov/connect/contact-us.html#joinus), forms on your page.

--- a/pages/documentation/forms.md
+++ b/pages/documentation/forms.md
@@ -10,27 +10,32 @@ This page will help you navigate form rules and choose what technology is approp
 A number of rules may apply to your federal agency's digital form. 
 
 ### The Paperwork Reduction Act (PRA)
-The Paperwork Reduction Act (PRA) determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if any how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
+The Paperwork Reduction Act determines how federal agencies collect information from the public. Adhering to this law doesn't have to be complicated: a fantastic guide has been written at [https://pra.digital.gov/](https://pra.digital.gov/) to help you understand if any how PRA is applicable to your form. Here's a quick preview of the basic steps you should take:
 
-1. To figure out if PRA applies to your form, first see if an exemption or generic clearance for common forms applies here:[https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
-2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/)In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more-basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed. 
+1. To figure out if PRA applies to your form, first see if an exemption or generic clearance for common forms applies here: [https://pra.digital.gov/do-i-need-clearance/](https://pra.digital.gov/do-i-need-clearance/)
+2. If you do need to get PRA approval, then start early! [https://pra.digital.gov/clearance-process/](https://pra.digital.gov/clearance-process/) In some cases it can take 6 to 9 months to get a form approved for your website. To avoid delaying your work, PRA experts recommend you first try to publish a more-basic version of your form that falls under a PRA exemption, while you wait for your full version to be reviewed.
 3. After you've started the PRA process, then build the form.
 4. Don't go it alone; get in touch with your agency's PRA contact. [https://pra.digital.gov/contact/](https://pra.digital.gov/contact/)
 
-### Privacy Act (PA)
-Add overview and link
+#### Accessibility
+The [21st Century IDEA Act](https://www.congress.gov/bill/115th-congress/house-bill/5759/text) applies to all executive agencies' public-facing websites. It mandates a modern user experience in government websites. Importantly, it requires accessibility compliance for users with disabilities. We recommend using the [United States Web Design System](https://designsystem.digital.gov/) for your form. Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
+- [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
+- A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/).
 
-### Additional rules that may apply
-- The 21st Century IDEA Act applies to all executive agencies' public-facing websites. Use USDWS code to build your form found [here] (https://designsystem.digital.gov/components/form-templates/) and [here] (https://designsystem.digital.gov/components/form-controls/), which have important usability guidance baked right in.  
-- While the PRA and PA primarily focus on how data is collected, it is the [Federal Records Act] (https://www.archives.gov/records-mgmt/faqs/federal.html) that focus on how that data is stored or destroyed. Contact [X] to find out more.
-- If you will be collecting sensitive health data, fill in with overview and link. Contact [X] to find out more.
+The USWDS has [508](https://www.section508.gov/manage/laws-and-policies) compliance built in. If you end up creating a form without using the USWDS, you'll need to do the work to make your form accessible. Use [https://accessibility.18f.gov/](https://accessibility.18f.gov/) as a guide.
+
+#### Privacy
+Any forms collecting Personally Identifiable Information (PII) will have to comply with their agency's Privacy process. Here is GSA's for reference: [https://before-you-ship.18f.gov/privacy/](https://before-you-ship.18f.gov/privacy/).
+
+#### SORN
+The Federal Records Act also requires that federal agencies publish a list of which systems they keep PII on. These are call System of Record Notices. Each agencies publishes a list, [here](https://www.gsa.gov/reference/gsa-privacy-program/systems-of-records-privacy-act/system-of-records-notices-sorns-privacy-act) is GSA's for reference.
 
 ## Choosing a form service
 Federalist pages are static websites; there is no backend for you to log into to get your form data. You'll need to use a separate form service to use a form on your webpage. Choosing a service depends on what the purpose of your form is. Here are some recommendations.
 
-- Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account.
-- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey. This service costs X.
-- Everything else - [Google Forms](https://gsuite.google.com/products/forms/). Google Forms can handle most all of your form needs for free. Below is more advice for Google Forms.
+- Newsletter Sign Ups - [GovDelivery](https://granicus.com/solution/govdelivery/) is the most common tool used for newsletters sign ups. Your agency probably already has an account. [HubSpot](https://www.hubspot.com/) is another service used by Federalist customers.
+- Customer Feedback - [Touchpoints](https://touchpoints.digital.gov) offers fast track PRA approval for a standardized customer feedback survey.
+- Contact forms, bug reporting, support requests - [Google Forms](https://gsuite.google.com/products/forms/). Google Forms can handle most of your form needs. Below is more advice for Google Forms.
 
 #### Google Forms
 Google Forms are easy to implement, secure, and customizable enough to handle whatever your form needs are. Here is advice on getting access to Google Forms and for adding them to your website with lots of examples.
@@ -42,23 +47,15 @@ Google Forms are easy to implement, secure, and customizable enough to handle wh
   </div>
 </div>
 
-Most other agencies, while they may not have an official Google GSuite account purchased for use, can still usually get Google Forms another way.
+Other agencies, while they may not have an official Google GSuite account purchased for use, can still usually get Google Forms another way.
 
 ##### Options for getting access to Google Forms
-* Create a Google Account with your government email [using this form](https://accounts.google.com/SignUpWithoutGmail).
+* Create a Google Account with [your government email](https://accounts.google.com/SignUpWithoutGmail).
 * Federalist staff can help set you up a with GSA Affiliated Customer Account (GACA).
-* Get a special waiver from their own agency.
+* Get a special waiver from your own agency.
 
 ##### Advice for using a Google Form
-Google Forms have a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
-
-The easiest way to include a Google Form on your page is to just link to it. Here is an [example](https://coe.gsa.gov/connect/contact-us.html#joinus) that links to a few different Google Forms.
-
-To maintain a consistent user experience and design for your forms, we recommend a more advanced technique though. You can write your own HTML form that posts the data to Google Forms. Here are some Federalist examples: [Example](https://tech.gsa.gov/work-with-us/#contact), [Example](https://www.afwerx.af.mil/join.html)
-
-Here is [a well written guide](https://blog.webjeda.com/google-form-customize/) for how to write your own HTML form that matches your created Google Form. You'll need to set your form's action url to post to the Google Form url, then set the correct name element for each of your form's questions. 
-
-#### USDWS advice
-If you are writing your own form HTML data, we recommend using the [United States Web Design System](https://designsystem.digital.gov/). Our Federalist [templates](https://federalist.18f.gov/documentation/templates/) are all built using the USWDS.
-- [The USWDS form elements](https://designsystem.digital.gov/components/form-controls/)
-- A few pre built [form templates](https://designsystem.digital.gov/components/form-templates/)
+* Google Forms have a setting that lets you restrict submissions to just users within your agency. Turn that on or off as appropriate for your form.
+* Text fields have a validation option explained [here](https://support.google.com/docs/answer/3378864?hl=en). This can be used to limit submissions to users with a `.gov` or `.mil` email address, as in this [example](https://docs.google.com/forms/d/e/1FAIpQLSePimoF0RkiCP62BSIL_yj0yMXEUePNJ9AabPJqq1Xzbp_GVg/viewform).
+* The easiest way to include a Google Form on your page is to just link to it. Here is an [example](https://coe.gsa.gov/connect/contact-us.html#joinus) that links to a few different Google Forms.
+* A more advanced technique is to write your own HTML form that posts the data directly to Google Forms. Here are some Federalist examples: [Example](https://tech.gsa.gov/work-with-us/#contact), [Example](https://www.afwerx.af.mil/join.html). This lets you maintain a consistent user experience and design for your forms.  Here is [a well written guide](https://blog.webjeda.com/google-form-customize/) for how to write your own HTML form that matches your created Google Form. You'll need to set your form's action url to post to the Google Form url, then set the correct name element for each of your form's questions. Good luck!


### PR DESCRIPTION
This PR will add a new page at https://federalist.18f.gov/documentation/forms/

This page will have documentation to help Federalist users add forms to their websites. Documentation is needed because forms in government are hard and forms on Federalist are hard. This page will describe how to:
- Navigate the Paperwork Reduction Act
- Choose a third party form service

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/add-forms-docs)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/add-forms-docs/)

Here is the direct preview link. https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/add-forms-docs/documentation/forms/

