### PR TITLE
edits to case studies summary

### DIFF
--- a/_data/case_studies.yml
+++ b/_data/case_studies.yml
@@ -1,6 +1,6 @@
 title: Trusted and scalable.
 summary: >-
-  Nine agencies use Federalist to host over 100 sites with over 140,000 page views per day. This page shows a sample of our partners.
+  Federalist hosts over 100+ sites across Federal agencies which account for over 140,000+ page views per day.
 items:
   - title: Vote.gov
     summary: >-


### PR DESCRIPTION
Starting with a low number makes the reach of Federalist sound super small
> Nine agencies use Federalist to host over 100 sites...

I made some edits to better frame this.

/cc @eddietejeda 



