### PR TITLE
Add Current default Ruby Version

### DIFF
--- a/pages/documentation/rvm-on-federalist.md
+++ b/pages/documentation/rvm-on-federalist.md
@@ -9,6 +9,9 @@ redirect_from:
 
 Federalist uses [RVM](https://rvm.io/) to select which ruby version to use to build a Federalist site.
 
+## Default Ruby version
+By default, the build will use Ruby version 2.6.3.
+
 ## Specifying a Ruby version
 
 Prior to building a site, the build will check for a file named `.ruby-version`. If one is found, it will use RVM to install and use the version specified there.


### PR DESCRIPTION
Adds the current default Ruby version to the documentation.

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/dc/add-ruby-version.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/dc/add-ruby-version)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/dc/add-ruby-version/)

This came out of a conversation on Slack with @stvnrlly .