### PR TITLE
removing duplicate heading

### DIFF
--- a/pages/documentation/custom-headers.md
+++ b/pages/documentation/custom-headers.md
@@ -5,8 +5,6 @@ layout: page
 sidenav: documentation
 ---
 
-# Custom Headers
-
  ⚠️ **This feature is currently experimental, make sure you know what you are doing!** ⚠️
 
 You can configure custom headers for your site by adding information under the `headers` key in the [Federalist configuration file](/documentation/federalist-json).


### PR DESCRIPTION
There was an H1 at the top of the page that duplicated the title of the page (which is also a H1)

