### PR TITLE
Update IDEA link "check out" to describe link destination

### DIFF
--- a/pages/documentation/21st-century-idea.md
+++ b/pages/documentation/21st-century-idea.md
@@ -19,4 +19,4 @@ All new, public-facing websites and digital services must meet eight specific re
 1. **Customizable** - provide an option for a more customized digital experience
 1. **Mobile-friendly** - be functional and usable on mobile devices
 
-To learn more about this law, [check out](https://digital.gov/resources/21st-century-integrated-digital-experience-act/).
+To learn more about this law, check out the [21st Century IDEA resource on Digital.gov](https://digital.gov/resources/21st-century-integrated-digital-experience-act/).


### PR DESCRIPTION
Proposed changes in this pull request:

- Updates the link text "check out" on the ["21st Century IDEA" page](https://federalist.18f.gov/documentation/21st-century-idea/) to be a complete sentence, describing the link destination as "21st Century IDEA resource on Digital.gov".

Currently, the link is presented as an incomplete sentence, with no context on where the link will navigate:

>To learn more about this law, [check out](https://digital.gov/resources/21st-century-integrated-digital-experience-act/).

See live: https://federalist.18f.gov/documentation/21st-century-idea/

Relevant guidance: https://content-guide.18f.gov/urls-and-filenames/#link-text

>This ultimately means that link text should be understandable independent of the text surrounding it. Avoid ambiguous link text like click here, here, or learn more whenever possible.

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/update/idea-link-digitalgov.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/update/idea-link-digitalgov)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/update/idea-link-digitalgov/)

