### PR TITLE
Add authentication requirements for users of Netlify CMS

### DIFF
--- a/pages/documentation/getting-started-with-netlify-cms.md
+++ b/pages/documentation/getting-started-with-netlify-cms.md
@@ -59,7 +59,7 @@ To use Netlify CMS, you must authenticate with Github, and in order for Federali
 See [Netlify CMS Backends Overview](https://www.netlifycms.org/docs/backends-overview) for a full description of the configuration options.
 
 ### Authentication Requirements
-Because Federalist facilitates the authentication with Github, we require users of Netlify CMS to be Federalist users in addition to Github having `write` permissions on the Github repository.
+Because Federalist facilitates the authentication with Github, we require users of Netlify CMS to be Federalist users in addition to having `write` permissions to the Github repository.
 
 ### Getting familiar with Netlify CMS
 To learn more about Netlify CMS and how it may help you manage content changes on your Federalist site, please visit [netlifycms.org/](https://www.netlifycms.org/)

--- a/pages/documentation/getting-started-with-netlify-cms.md
+++ b/pages/documentation/getting-started-with-netlify-cms.md
@@ -58,6 +58,8 @@ To use Netlify CMS, you must authenticate with Github, and in order for Federali
 
 See [Netlify CMS Backends Overview](https://www.netlifycms.org/docs/backends-overview) for a full description of the configuration options.
 
+### Authentication Requirements
+Because Federalist facilitates the authentication with Github, we require users of Netlify CMS to be Federalist users in addition to Github having `write` permissions on the Github repository.
 
 ### Getting familiar with Netlify CMS
 To learn more about Netlify CMS and how it may help you manage content changes on your Federalist site, please visit [netlifycms.org/](https://www.netlifycms.org/)


### PR DESCRIPTION
Fixes issue(s) #447 .

Proposed changes in this pull request:
- Add documentation for Netlify CMS authentication requirements


[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/447-netlify-cms-auth-docs)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/447-netlify-cms-auth-docs/)

