### PR TITLE
Add docs for `fullClone` federalist.json config option

### DIFF
--- a/pages/documentation/federalist-json.md
+++ b/pages/documentation/federalist-json.md
@@ -21,7 +21,7 @@ See [specifying custom headers](/documentation/custom-headers) for details.
 | anything else | | shallow clone |
 
 
-By default, Federalist does a "shallow" clone of a single branch of your repository to minimize the duration of your build as well as the space it requires. This means that entire git revision is NOT available during Federalist builds which may differ from your local environment. This can cause an issue with some site engines or plugins that generate "last modified" datetimes base on the git revision history for particular files.
+By default, Federalist does a "shallow" clone of a single branch of your repository to minimize the duration of your build as well as the space it requires. This means that the entire git revision history is NOT available during Federalist builds, which may differ from your local environment. This can cause an issue with some site engines or plugins that generate "last modified" datetimes based on the git revision history for particular files.
 
 Examples:
 - Hugo: `.Page.Lastmod` with configuration option `enableGitInfo = true`

--- a/pages/documentation/federalist-json.md
+++ b/pages/documentation/federalist-json.md
@@ -5,4 +5,35 @@ layout: page
 sidenav: documentation
 ---
 
-Federalist-specific configuration can be done in a `federalist.json` file in the root of your project. Currently, we only support [specifying custom headers](/documentation/custom-headers).
+Federalist-specific configuration can be done in a `federalist.json` file in the root of your project. Currently, we only support the following keys:
+- `headers`
+- `fullClone`
+
+## `headers`
+See [specifying custom headers](/documentation/custom-headers) for details.
+
+## `fullClone`
+
+| values | default? | effect |
+| ------ |:--------:| ------ |
+| not specified | **Y** | shallow clone |
+| `true` | | full clone |
+| anything else | | shallow clone |
+
+
+By default, Federalist does a "shallow" clone of a single branch of your repository to minimize the space required for and duration of your build. This means that entire git revision is NOT available during Federalist builds which may differ from your local environment. This can cause an issue with some site engines or plugins that generate "last modified" datetimes base on the git revision history for particular files.
+
+Examples:
+- Hugo: `.Page.Lastmod` with configuration option `enableGitInfo = true`
+- Jekyll: [jekyll-last-modified-at](https://github.com/gjtorikian/jekyll-last-modified-at)
+
+Setting `"fullClone": true` in your `federalist.json` file will tell Federalist to pull the entire revision history for the specific branch.
+
+Ex.
+```js
+// federalist.json
+{
+  ...
+  "fullClone": true
+}
+```

--- a/pages/documentation/federalist-json.md
+++ b/pages/documentation/federalist-json.md
@@ -29,6 +29,8 @@ Examples:
 
 Setting `"fullClone": true` in your `federalist.json` file will tell Federalist to pull the entire revision history for the specific branch.
 
+**Note:** For larger repositories this may cause a noticiable increase in build time.
+
 Ex.
 ```js
 // federalist.json

--- a/pages/documentation/federalist-json.md
+++ b/pages/documentation/federalist-json.md
@@ -21,7 +21,7 @@ See [specifying custom headers](/documentation/custom-headers) for details.
 | anything else | | shallow clone |
 
 
-By default, Federalist does a "shallow" clone of a single branch of your repository to minimize the space required for and duration of your build. This means that entire git revision is NOT available during Federalist builds which may differ from your local environment. This can cause an issue with some site engines or plugins that generate "last modified" datetimes base on the git revision history for particular files.
+By default, Federalist does a "shallow" clone of a single branch of your repository to minimize the duration of your build as well as the space it requires. This means that entire git revision is NOT available during Federalist builds which may differ from your local environment. This can cause an issue with some site engines or plugins that generate "last modified" datetimes base on the git revision history for particular files.
 
 Examples:
 - Hugo: `.Page.Lastmod` with configuration option `enableGitInfo = true`


### PR DESCRIPTION
Fixes issue(s) https://github.com/18F/federalist-garden-build/issues/281.

Proposed changes in this pull request:
- Add docs for `fullClone` federalist.json config option


[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/fgb281-fullclone-config-option.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/fgb281-fullclone-config-option)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/fgb281-fullclone-config-option/)

