### PR TITLE
450 update dap subagency

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ google_analytics_ua: UA-48605964-31
 
 # Configuration for DAP, add your agency ID here:
 dap_agency: GSA
+dap_subagency: TTS,Federalist
 
 # To enable search, uncomment the search section
 # You will need to setup a search account with search.gov

--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,0 +1,21 @@
+<!--
+  Copied verbatim from 18f/uswds-jekyll v5
+  Can be removed once we upgrade
+ -->
+{% if site.google_analytics_ua %}
+<!-- Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics_ua }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag() { dataLayer.push(arguments); }
+  gtag('js', new Date());
+
+  // `forceSSL` was used for analytics.js (the older Google Analytics script). It isn't documented for gtag.js, but the term occurs in the gtag.js code; figure it doesn't hurt to leave it in. -@afeld, 5/29/19
+  gtag('config', '{{ site.google_analytics_ua }}', { 'anonymize_ip': true, 'forceSSL': true });
+</script>
+{% endif %}
+
+{% if site.dap_agency %}
+<!-- Digital Analytics Program roll-up, see https://analytics.usa.gov for data -->
+<script id="_fed_an_ua_tag" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency={{ site.dap_agency }}{% if site.dap_subagency %}&subagency={{ site.dap_subagency }}{% endif %}"></script>
+{% endif %}


### PR DESCRIPTION
Fixes issue(s) #450 .

Proposed changes in this pull request:
- Configures DAP subagency
- Adds custom analytics header until upgrade to uswds-jekyll v5

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/450-update-dap-subagency .svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/450-update-dap-subagency )

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/450-update-dap-subagency /)

