### PR TITLE
Initial language for adding hourly support pricing

### DIFF
--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -12,6 +12,7 @@ plans:
   - title: "Platform Support $27,500/100 hours"
     features:
       - { text: "Personalized on-boarding with review of Federalist features and Github integration." }
-      - { text: "Weekly office hours to answer questions and best practices." }
-      - { text: "Review of U.S Web Design System, Digital Analytics Program, and Search.gov integrations." }
+      - { text: "Weekly office hours to answer platform questions." }
+      - { text: "Implement best practices for static site generation, git-based CMS architecture, and Federalist deployments." }
+      - { text: "Review of U.S Web Design System, Digital Analytics Program, Search.gov, and Netlify CMS integrations." }
       - { text: "Troubleshooting issues with site builds." }

--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -9,3 +9,9 @@ plans:
       - { text: Automatic HTTPS certificates and renewals for all your websites. }
       - { text: Unlimited sites for your office. }
       - { text: No charges for storage or bandwidth. }
+  - title: "Platform Support $27,500/100 hours"
+    features:
+      - { text: "Personalized on-boarding with review of Federalist features and Github integrations." }
+      - { text: "Weekly office hours to answer questions and best practices." }
+      - { text: "Review of U.S Web Design System, Digital Analytics Program, and Search.gov integrations." }
+      - { text: "Troubleshooting issues with site builds." }

--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -13,6 +13,6 @@ plans:
     features:
       - { text: "Personalized on-boarding with review of Federalist features and Github integration." }
       - { text: "Weekly office hours to answer platform questions." }
-      - { text: "Implement best practices for static site generation, git-based CMS architecture, and Federalist deployments." }
+      - { text: "Hands-on guidance to help implement best practices for static site generation, git-based CMS architecture, and Federalist deployments." }
       - { text: "Review of U.S Web Design System, Digital Analytics Program, Search.gov, and Netlify CMS integrations." }
       - { text: "Troubleshooting issues with site builds." }

--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -11,7 +11,7 @@ plans:
       - { text: No charges for storage or bandwidth. }
   - title: "Platform Support $27,500/100 hours"
     features:
-      - { text: "Personalized on-boarding with review of Federalist features and Github integrations." }
+      - { text: "Personalized on-boarding with review of Federalist features and Github integration." }
       - { text: "Weekly office hours to answer questions and best practices." }
       - { text: "Review of U.S Web Design System, Digital Analytics Program, and Search.gov integrations." }
       - { text: "Troubleshooting issues with site builds." }


### PR DESCRIPTION
Looking for as much feedback as possible.

Proposed changes in this pull request:
- Add support package to pricing page
- Proposing 100 hours 
- An list of the package's deliverables

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/apb%2Fsupport-pricing)

[:sunglasses: PREVIEW](https://federalist-a44a7672-afb1-473e-acb2-067f644c0967.app.cloud.gov/preview/18f/federalist.18f.gov/apb/support-pricing/pricing/)

cc @RonWilliams