### PR TITLE
Add url to Jekyll config to fix sitemaps

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,8 @@ title: Federalist
 name: Federalist Homepage
 theme: uswds-jekyll
 
+url: https://federalist.18f.gov
+
 # Configuration for Google Analytics, add your UA code here:
 google_analytics_ua: UA-48605964-31
 


### PR DESCRIPTION
Adds url to ensure sitemap contains full urls
