### PR TITLE
Add examples to default env vars documentation

### DIFF
--- a/pages/documentation/env-vars-federalist.md
+++ b/pages/documentation/env-vars-federalist.md
@@ -12,15 +12,69 @@ At the time your site is built, a number of special environment variables are ex
 
 ## Default environment variables
 
-When Federalist builds your site it makes available the following environment variables:
+When Federalist builds your site it makes available the following environment variables, which change depending on the environment (`preview`, `demo`, or `site`) being deployed to:
 
-Name|Description|Example
----|---|---
-BRANCH|Github branch being built|`main`
-OWNER|Owner of Github repository|`cloud-gov`
-REPOSITORY|Github repository|`my-website`
-SITE_PREFIX|Path of s3 bucket in which your site will be deployed|`site/cloud-gov/my-website`
-BASEURL|Path for deployed site|`''`
+<table>
+<thead>
+<tr>
+<th rowspan="2">Name</th>
+<th rowspan="2">Description</th>
+<th colspan="2" style="text-align: center">Example</th>
+</tr>
+<tr>
+<th>Preview</th>
+<th>Site (Live)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>BRANCH</td>
+<td>Github branch being built</td>
+<td markdown="1">
+`new-feature`
+</td>
+<td markdown="1">
+`main`
+</td>
+</tr>
+<tr>
+<td>OWNER</td>
+<td>Owner of Github repository</td>
+<td markdown="1" colspan="2" style="text-align: center">
+`cloud-gov`
+</td>
+</tr>
+<tr>
+<td>REPOSITORY</td>
+<td>Github repository</td>
+<td markdown="1" colspan="2" style="text-align: center">
+`my-website`
+</td>
+</tr>
+<tr>
+<td>SITE_PREFIX</td>
+<td>Path of s3 bucket in which your site will be deployed</td>
+<td markdown="1">
+`preview/cloud-gov/my-website/new-feature`
+</td>
+<td markdown="1">
+`site/cloud-gov/my-website`
+</td>
+</tr>
+<tr>
+<td>BASEURL</td>
+<td markdown="1">
+Path for deployed site (empty string when using a custom domain, otherwise the same as `SITE_PREFIX`)
+</td>
+<td markdown="1">
+`/preview/cloud-gov/my-website/new-feature`
+</td>
+<td markdown="1">
+`''`
+</td>
+</tr>
+</tbody>
+</table>
 
 ## Adding custom environment variables
 

--- a/pages/documentation/env-vars-federalist.md
+++ b/pages/documentation/env-vars-federalist.md
@@ -14,13 +14,13 @@ At the time your site is built, a number of special environment variables are ex
 
 When Federalist builds your site it makes available the following environment variables:
 
-Name|Description
----|---
-BRANCH|Github branch being built
-OWNER|Owner of Github repository
-REPOSITORY|Github repository
-SITE_PREFIX|Path of s3 bucket in which your site will be deployed
-BASEURL|Path for deployed site
+Name|Description|Example
+---|---|---
+BRANCH|Github branch being built|`main`
+OWNER|Owner of Github repository|`cloud-gov`
+REPOSITORY|Github repository|`my-website`
+SITE_PREFIX|Path of s3 bucket in which your site will be deployed|`site/cloud-gov/my-website`
+BASEURL|Path for deployed site|`''`
 
 ## Adding custom environment variables
 

--- a/pages/documentation/env-vars-federalist.md
+++ b/pages/documentation/env-vars-federalist.md
@@ -14,67 +14,13 @@ At the time your site is built, a number of special environment variables are ex
 
 When Federalist builds your site it makes available the following environment variables, which change depending on the environment (`preview`, `demo`, or `site`) being deployed to:
 
-<table>
-<thead>
-<tr>
-<th rowspan="2">Name</th>
-<th rowspan="2">Description</th>
-<th colspan="2" style="text-align: center">Example</th>
-</tr>
-<tr>
-<th>Preview</th>
-<th>Site (Live)</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>BRANCH</td>
-<td>Github branch being built</td>
-<td markdown="1">
-`new-feature`
-</td>
-<td markdown="1">
-`main`
-</td>
-</tr>
-<tr>
-<td>OWNER</td>
-<td>Owner of Github repository</td>
-<td markdown="1" colspan="2" style="text-align: center">
-`cloud-gov`
-</td>
-</tr>
-<tr>
-<td>REPOSITORY</td>
-<td>Github repository</td>
-<td markdown="1" colspan="2" style="text-align: center">
-`my-website`
-</td>
-</tr>
-<tr>
-<td>SITE_PREFIX</td>
-<td>Path of s3 bucket in which your site will be deployed</td>
-<td markdown="1">
-`preview/cloud-gov/my-website/new-feature`
-</td>
-<td markdown="1">
-`site/cloud-gov/my-website`
-</td>
-</tr>
-<tr>
-<td>BASEURL</td>
-<td markdown="1">
-Path for deployed site (empty string when using a custom domain, otherwise the same as `SITE_PREFIX`)
-</td>
-<td markdown="1">
-`/preview/cloud-gov/my-website/new-feature`
-</td>
-<td markdown="1">
-`''`
-</td>
-</tr>
-</tbody>
-</table>
+Name|Description|Examples
+---|---|---
+BRANCH|Github branch being built|`new-feature`, `main`, …
+OWNER|Owner of Github repository|`18f`, `cloud-gov`, …
+REPOSITORY|Github repository|`my-website`, `uswds-site`, …
+SITE_PREFIX|Path of s3 bucket in which your site will be deployed|`preview/cloud-gov/my-website/new-feature`, `site/cloud-gov/my-website`, …
+BASEURL|Path for deployed site (empty string when using a custom domain, otherwise the same as `SITE_PREFIX`)|`/preview/cloud-gov/my-website/new-feature`, `''`, …
 
 ## Adding custom environment variables
 


### PR DESCRIPTION
Re issue(s) https://github.com/18F/federalist.18f.gov/issues/546.

Proposed changes in this pull request:
- Add examples to default env vars documentation

<img width="759" alt="Screen Shot 2022-03-31 at 11 39 26 AM" src="https://user-images.githubusercontent.com/1178494/161095010-347a76d5-ed9a-4350-9426-783cecd5ea3a.png">

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/bh-env-var-docs.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/bh-env-var-docs)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/bh-env-var-docs/)

