### PR TITLE
Add documentation about Ruby EOL

### DIFF
--- a/pages/documentation/rvm-on-federalist.md
+++ b/pages/documentation/rvm-on-federalist.md
@@ -27,4 +27,4 @@ When specifying a version using `.ruby-version`, please be aware of the followin
 - _security maintenance_ (security fix): Only security fixes are backported to this branch.
 - _eol (end-of-life)_: Branch is not supported by the ruby-core team any longer and does not receive any fixes. No further patch release will be released.
 
-Once a version reaches EOL, it will no longer receive any new fixes. Due to this, Federalist is unable to build or update a site that is using a deprecated version. To view the current maintenance status of various Ruby versions, please visit [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/).
+Once a version reaches EOL, it will no longer receive any new fixes. Due to this, Federalist is unable to build or update a site that is using an EOL version of Ruby. To view the current maintenance status of various Ruby versions, please visit [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/).

--- a/pages/documentation/rvm-on-federalist.md
+++ b/pages/documentation/rvm-on-federalist.md
@@ -10,10 +10,21 @@ redirect_from:
 Federalist uses [RVM](https://rvm.io/) to select which ruby version to use to build a Federalist site.
 
 ## Default Ruby version
-By default, the build will use Ruby version 2.6.6.
+
+By default, the build will use Ruby version 2.7.5.
 
 ## Specifying a Ruby version
 
 Prior to building a site, the build will check for a file named `.ruby-version`. If one is found, it will use RVM to install and use the version specified there.
 
-For example, if you wish to use Ruby version 2.4.0 to build a site, add a new file named `.ruby-version` to your repository. The `.ruby-version` file should be at the top-level directory. The contents of that file should be "`2.4.0`".
+For example, if you wish to use Ruby version 2.7.4 to build a site, add a new file named `.ruby-version` to your repository. The `.ruby-version` file should be at the top-level directory. The contents of that file should be "`2.7.4`".
+
+## End of life (EOL)
+
+When specifying a version using `.ruby-version`, please be aware of the following maintenance stages:
+
+- _normal maintenance_ (bug fix): Branch receives general bug fixes and security fixes.
+- _security maintenance_ (security fix): Only security fixes are backported to this branch.
+- _eol (end-of-life)_: Branch is not supported by the ruby-core team any longer and does not receive any fixes. No further patch release will be released.
+
+Once a version reaches EOL, it will no longer receive any new fixes. Due to this, Federalist is unable to build or update a site that is using a deprecated version. To view the current maintenance status of various Ruby versions, please visit [Ruby Maintenance Branches](https://www.ruby-lang.org/en/downloads/branches/).

--- a/pages/documentation/rvm-on-federalist.md
+++ b/pages/documentation/rvm-on-federalist.md
@@ -21,7 +21,7 @@ For example, if you wish to use Ruby version 2.7.4 to build a site, add a new fi
 
 ## End of life (EOL)
 
-When specifying a version using `.ruby-version`, please be aware of the following maintenance stages:
+When specifying a version using `.ruby-version`, please be aware of the following maintenance stages for released versions of Ruby:
 
 - _normal maintenance_ (bug fix): Branch receives general bug fixes and security fixes.
 - _security maintenance_ (security fix): Only security fixes are backported to this branch.


### PR DESCRIPTION
Proposed changes in this pull request:
- Add information about Ruby maintenance and EOL

<img width="605" alt="Screen Shot 2022-04-08 at 11 22 48 AM" src="https://user-images.githubusercontent.com/1178494/162473218-af6d3dc9-17c2-40e3-856f-445ba136b61a.png">

[![CircleCI](https://circleci.com/gh/18F/federalist.18f.gov/tree/bh-ruby-eol.svg?style=svg)](https://circleci.com/gh/18F/federalist.18f.gov/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/18f/federalist.18f.gov/bh-ruby-eol/)

