### PR TITLE
Update current NodeJS LTS version

### DIFF
--- a/pages/documentation/node-on-federalist.md
+++ b/pages/documentation/node-on-federalist.md
@@ -27,7 +27,7 @@ See [npm-ci](https://docs.npmjs.com/cli/ci) and [npm-install](https://docs.npmjs
 
 ## Specifying a Node version
 
-Federalist only supports active and maintenance LTS (Long Term Support) [Node releases](https://nodejs.org/en/about/releases/), the default version is currently v14.x (fermium).
+Federalist only supports active and maintenance LTS (Long Term Support) [Node releases](https://nodejs.org/en/about/releases/), the default version is currently v16.x (gallium).
 
 You can specify a different version than the default by providing a file named `.nvmrc` at the root of your repository containing the desired version of Node. However, if an unsupported version is specified, the build will fail with a helpful error message. 
 


### PR DESCRIPTION
Proposed changes in this pull request:
- Update the "Node on Federalist" doc to reflect the recent change to NodeJS 16.x Gallium LTS

/cc @hursey013  - You mentioned in Slack that Federalist recently began running NodeJS 16 instead of 14 and I noticed this doc was out of date.